### PR TITLE
[Copy] 将“地下”图层选项改为“主世界洞穴 / 下界顶层”

### DIFF
--- a/src/main/resources/assets/confluxmap/lang/en_us.json
+++ b/src/main/resources/assets/confluxmap/lang/en_us.json
@@ -330,7 +330,7 @@
   "confluxmap.config.shape.circle": "Circle",
   "confluxmap.config.layer_override.auto": "Auto",
   "confluxmap.config.layer_override.force_surface": "Surface",
-  "confluxmap.config.layer_override.force_underground": "Underground",
+  "confluxmap.config.layer_override.force_underground": "Overworld Cave / Nether Roof",
   "confluxmap.value.on": "On",
   "confluxmap.value.off": "Off",
   "confluxmap.value.unlimited": "Unlimited",

--- a/src/main/resources/assets/confluxmap/lang/zh_cn.json
+++ b/src/main/resources/assets/confluxmap/lang/zh_cn.json
@@ -330,7 +330,7 @@
   "confluxmap.config.shape.circle": "圆形",
   "confluxmap.config.layer_override.auto": "自动",
   "confluxmap.config.layer_override.force_surface": "地表",
-  "confluxmap.config.layer_override.force_underground": "地下",
+  "confluxmap.config.layer_override.force_underground": "主世界洞穴 / 下界顶层",
   "confluxmap.value.on": "开启",
   "confluxmap.value.off": "关闭",
   "confluxmap.value.unlimited": "无限制",


### PR DESCRIPTION
## 修改内容

- 简体中文：`地下` → `主世界洞穴 / 下界顶层`
- 英文：`Underground` → `Overworld Cave / Nether Roof`

## 修改原因

该图层覆盖选项在主世界中会切换到洞穴图层，在下界中会切换到基岩顶层。原有的“地下 / Underground”只表达了主世界中的效果，玩家在下界中容易将它理解为当前位置附近的地下地图。

新文案同时说明该选项在两个维度中的作用，并在切换维度后保持一致。现有图层选择逻辑保持原样。

## 验证

- 中英文语言文件均可正常解析
- 两份语言文件各包含 355 个翻译键
- 翻译键和格式化占位符保持一致
- Git 差异检查通过