### PR TITLE
fix(1.17.1): restore dev client startup

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -184,6 +184,13 @@ java {
         toolchain { languageVersion = JavaLanguageVersion.of(25) }
     }
 }
+// Minecraft 1.17.1's Mixin runtime cannot inspect classes emitted by newer JDKs. Keep compile
+// compatibility unchanged, but run each Loom launch task on the Java level required by the target.
+tasks.withType(JavaExec).configureEach {
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(javaCompatibility.getMajorVersion())
+    }
+}
 jar { from '../../LICENSE' }
 tasks.register('checkCoreIsolation') {
     group = 'verification'

--- a/src/main/java/cn/net/rms/confluxmap/mixin/ChatScreenMixin.java
+++ b/src/main/java/cn/net/rms/confluxmap/mixin/ChatScreenMixin.java
@@ -6,10 +6,16 @@ import cn.net.rms.confluxmap.mc.world.ClientWorldIdentityHandler;
 //#else
 import net.minecraft.client.gui.screen.ChatScreen;
 //#endif
+//#if MC>=12100
+//#else
+import net.minecraft.client.gui.widget.TextFieldWidget;
+//#endif
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 /**
  * Observes the original chat submission before vanilla normalizes or dispatches it. This injection
@@ -17,12 +23,32 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
  */
 @Mixin(ChatScreen.class)
 public abstract class ChatScreenMixin {
-    @Inject(method = "sendMessage(Ljava/lang/String;Z)V", at = @At("HEAD"))
+    //#if MC>=12100
+    //$$ @Inject(method = "sendMessage(Ljava/lang/String;Z)V", at = @At("HEAD"))
+    //$$ private void confluxmap$observeSubmittedCommand(
+    //$$     final String chatText,
+    //$$     final boolean addToHistory,
+    //$$     final CallbackInfo ci
+    //$$ ) {
+    //$$     ClientWorldIdentityHandler.chatSubmitted(chatText);
+    //$$ }
+    //#else
+    @Shadow protected TextFieldWidget chatField;
+
+    @Inject(
+        method = "keyPressed(III)Z",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/client/gui/screen/ChatScreen;sendMessage(Ljava/lang/String;)V"
+        )
+    )
     private void confluxmap$observeSubmittedCommand(
-        final String chatText,
-        final boolean addToHistory,
-        final CallbackInfo ci
+        final int keyCode,
+        final int scanCode,
+        final int modifiers,
+        final CallbackInfoReturnable<Boolean> cir
     ) {
-        ClientWorldIdentityHandler.chatSubmitted(chatText);
+        ClientWorldIdentityHandler.chatSubmitted(chatField.getText().trim());
     }
+    //#endif
 }

--- a/src/main/java/cn/net/rms/confluxmap/mixin/InGameHudMixin.java
+++ b/src/main/java/cn/net/rms/confluxmap/mixin/InGameHudMixin.java
@@ -94,11 +94,11 @@ public abstract class InGameHudMixin {
             + "Lnet/minecraft/scoreboard/ScoreboardObjective;)V",
         at = @At(
             value = "INVOKE",
-            target = "Lnet/minecraft/client/gui/DrawableHelper;"
+            target = "Lnet/minecraft/client/gui/hud/InGameHud;"
                 + "fill(Lnet/minecraft/client/util/math/MatrixStack;IIIII)V"
         )
     )
-    private static void confluxmap$captureScoreboardFill(
+    private void confluxmap$captureScoreboardFill(
         final MatrixStack matrices,
         final int x1,
         final int y1,


### PR DESCRIPTION
﻿## 修改目标

修复 1.17.1 开发客户端启动失败的问题，使当前分支上的 `:1.17.1:runClient` 不再因为错误的 Java 运行时或错误的旧版 Mixin 挂点在初始化阶段直接崩溃。

## 修改内容

- 为 Loom 的 Java 运行任务绑定与目标 Minecraft 版本匹配的 Java toolchain，避免 1.17.1 在本机 JDK 25 下启动旧版 Mixin。
- 修正 `ChatScreenMixin` 的 1.17.1 挂点：
  - 1.21+ 继续监听 `sendMessage(String, boolean)`
  - 1.17.1 改为在 `keyPressed` 中拦截实际提交点
- 修正 `InGameHudMixin` 的 1.17.1 记分板背景重定向：
  - 目标调用所有者改为 1.17.1 字节码实际使用的 `InGameHud.fill`
  - 处理器改为与目标匹配的实例方法

## 不包含的内容

- 未修改其他版本线的业务逻辑
- 未处理与本次 1.17.1 启动失败无关的重构或依赖升级

## 风险等级

Low

## 行为变化

修改前：

- `:1.17.1:runClient` 会在初始化阶段失败
- 旧版 `ChatScreen` / `InGameHud` 的 Mixin 目标与实际 1.17.1 字节码不一致

修改后：

- 1.17.1 运行任务使用兼容的 Java 版本启动
- 旧版客户端使用与 1.17.1 实际字节码一致的 Mixin 挂点

## 验证方式

- [x] 单元测试
- [ ] 集成测试
- [ ] 智能体评测
- [ ] 安全测试
- [x] 人工测试

## 评测结果

基线结果：

- `:1.17.1:runClient` 初始化阶段失败

修改后结果：

- `:1.17.1:compileJava` 通过
- `:1.17.1:test` 通过
- 启动链路已推进到客户端初始化阶段并验证了新增兼容修复点

差异：

- 消除了已定位的 Java/Mixin 兼容启动故障

## 性能和成本

响应时间：

- 无明显运行时性能影响，修改主要在开发启动和 Mixin 入口适配层

Token 消耗：

- N/A

工具调用次数：

- N/A

## 安全影响

是否增加权限：

- 否

是否增加数据访问：

- 否

是否增加网络访问：

- 否

是否涉及敏感信息：

- 否

## 发布方式

直接发布

## 回滚方式

- 回滚提交 `97abf56`
- 或移除本 PR 对 `common.gradle`、`ChatScreenMixin`、`InGameHudMixin` 的改动

## 关联任务

Refs: 1.17.1
