### PR TITLE
fix(map): follow detached camera entities

### DIFF
--- a/common/src/main/java/cn/net/rms/confluxmap/bridge/GameBridge.java
+++ b/common/src/main/java/cn/net/rms/confluxmap/bridge/GameBridge.java
@@ -22,6 +22,18 @@ public interface GameBridge {
         return player(1.0F);
     }
 
+    /**
+     * Active client viewpoint, which may belong to a detached camera entity. Implementations
+     * fall back to {@link #player(float)} while no separate camera entity is available.
+     */
+    default Optional<PlayerView> viewpoint(final float tickDelta) {
+        return player(tickDelta);
+    }
+
+    default Optional<PlayerView> viewpoint() {
+        return viewpoint(1.0F);
+    }
+
     /** Run a task on the render thread (next frame at the latest). */
     void runOnRenderThread(Runnable task);
 }

--- a/common/src/main/java/cn/net/rms/confluxmap/bridge/PlayerView.java
+++ b/common/src/main/java/cn/net/rms/confluxmap/bridge/PlayerView.java
@@ -2,7 +2,7 @@ package cn.net.rms.confluxmap.bridge;
 
 import cn.net.rms.confluxmap.core.model.DimensionId;
 
-/** Immutable snapshot of the local player's pose, taken on the main thread. */
+/** Immutable snapshot of a player or client-viewpoint pose, taken on the main thread. */
 public record PlayerView(
     double x,
     double y,

--- a/src/main/java/cn/net/rms/confluxmap/mc/McGameBridge.java
+++ b/src/main/java/cn/net/rms/confluxmap/mc/McGameBridge.java
@@ -31,6 +31,15 @@ public final class McGameBridge implements GameBridge {
         if (player == null || client.world == null) {
             return Optional.empty();
         }
+        return viewOf(player, tickDelta);
+    }
+
+    @Override
+    public Optional<PlayerView> viewpoint(final float tickDelta) {
+        final ClientPlayerEntity player = client.player;
+        if (player == null || client.world == null) {
+            return Optional.empty();
+        }
         // Some client-side mods temporarily move the camera into a separate entity (for
         // example while the player's soul is detached from their body).  Map overlays are
         // screen-space views, so anchoring them to the player entity in that state makes the
@@ -39,12 +48,16 @@ public final class McGameBridge implements GameBridge {
         // teardown and on versions where no camera entity is available yet.
         final Entity cameraEntity = client.getCameraEntity();
         final Entity viewEntity = cameraEntity != null ? cameraEntity : player;
+        return viewOf(viewEntity, tickDelta);
+    }
+
+    private Optional<PlayerView> viewOf(final Entity entity, final float tickDelta) {
         final Identifier dim = client.world.getRegistryKey().getValue();
         return Optional.of(new PlayerView(
-            MathHelper.lerp(tickDelta, viewEntity.prevX, viewEntity.getX()),
-            MathHelper.lerp(tickDelta, viewEntity.prevY, viewEntity.getY()),
-            MathHelper.lerp(tickDelta, viewEntity.prevZ, viewEntity.getZ()),
-            viewEntity.getYaw(tickDelta),
+            MathHelper.lerp(tickDelta, entity.prevX, entity.getX()),
+            MathHelper.lerp(tickDelta, entity.prevY, entity.getY()),
+            MathHelper.lerp(tickDelta, entity.prevZ, entity.getZ()),
+            entity.getYaw(tickDelta),
             DimensionId.of(dim.getNamespace(), dim.getPath())
         ));
     }

--- a/src/main/java/cn/net/rms/confluxmap/mc/McGameBridge.java
+++ b/src/main/java/cn/net/rms/confluxmap/mc/McGameBridge.java
@@ -7,6 +7,7 @@ import cn.net.rms.confluxmap.core.task.SessionGuard;
 import java.util.Optional;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.entity.Entity;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.MathHelper;
 
@@ -30,12 +31,20 @@ public final class McGameBridge implements GameBridge {
         if (player == null || client.world == null) {
             return Optional.empty();
         }
+        // Some client-side mods temporarily move the camera into a separate entity (for
+        // example while the player's soul is detached from their body).  Map overlays are
+        // screen-space views, so anchoring them to the player entity in that state makes the
+        // map, markers, and waypoints appear to slide away from the actual view.  Vanilla
+        // normally returns the player here; the fallback keeps this bridge safe during camera
+        // teardown and on versions where no camera entity is available yet.
+        final Entity cameraEntity = client.getCameraEntity();
+        final Entity viewEntity = cameraEntity != null ? cameraEntity : player;
         final Identifier dim = client.world.getRegistryKey().getValue();
         return Optional.of(new PlayerView(
-            MathHelper.lerp(tickDelta, player.prevX, player.getX()),
-            MathHelper.lerp(tickDelta, player.prevY, player.getY()),
-            MathHelper.lerp(tickDelta, player.prevZ, player.getZ()),
-            player.getYaw(tickDelta),
+            MathHelper.lerp(tickDelta, viewEntity.prevX, viewEntity.getX()),
+            MathHelper.lerp(tickDelta, viewEntity.prevY, viewEntity.getY()),
+            MathHelper.lerp(tickDelta, viewEntity.prevZ, viewEntity.getZ()),
+            viewEntity.getYaw(tickDelta),
             DimensionId.of(dim.getNamespace(), dim.getPath())
         ));
     }

--- a/src/main/java/cn/net/rms/confluxmap/mc/radar/EntityRadarScanner.java
+++ b/src/main/java/cn/net/rms/confluxmap/mc/radar/EntityRadarScanner.java
@@ -144,15 +144,17 @@ public final class EntityRadarScanner {
         if (self == null || client.world == null) {
             return List.of();
         }
-        final double px = self.getX();
-        final double py = self.getY();
-        final double pz = self.getZ();
+        final Entity cameraEntity = client.getCameraEntity();
+        final Entity observer = cameraEntity != null ? cameraEntity : self;
+        final double ox = observer.getX();
+        final double oy = observer.getY();
+        final double oz = observer.getZ();
         final double bufferedRadius = radius + SCAN_RANGE_BUFFER;
         final double horizontalRangeSq = bufferedRadius * bufferedRadius;
 
         final List<RadarEntry> raw = new ArrayList<>();
         for (final Entity entity : client.world.getEntities()) {
-            if (entity == self) {
+            if (entity == self || entity == observer) {
                 continue;
             }
             // Spectators are kept (flagged for translucent rendering) rather than hidden, and
@@ -166,12 +168,12 @@ public final class EntityRadarScanner {
                 continue;
             }
 
-            final double dx = entity.getX() - px;
-            final double dz = entity.getZ() - pz;
+            final double dx = entity.getX() - ox;
+            final double dz = entity.getZ() - oz;
             if (dx * dx + dz * dz > horizontalRangeSq) {
                 continue;
             }
-            final int yDelta = (int) Math.round(entity.getY() - py);
+            final int yDelta = (int) Math.round(entity.getY() - oy);
             final int verticalRange = (entity instanceof PhantomEntity ? PHANTOM_VERTICAL_RANGE : VERTICAL_RANGE) + SCAN_RANGE_BUFFER;
             if (Math.abs(yDelta) > verticalRange) {
                 continue;
@@ -189,7 +191,7 @@ public final class EntityRadarScanner {
         final RadarFilter filter = new RadarFilter(
             config.radarShowPlayers, config.radarShowHostile, config.radarShowPassive, config.radarShowOther, config.radarMaxEntities
         );
-        return filter.apply(raw, px, pz);
+        return filter.apply(raw, ox, oz);
     }
 
     private static RadarCategory classify(final Entity entity) {

--- a/src/main/java/cn/net/rms/confluxmap/mc/ui/hud/MinimapHudRenderer.java
+++ b/src/main/java/cn/net/rms/confluxmap/mc/ui/hud/MinimapHudRenderer.java
@@ -40,6 +40,7 @@ import cn.net.rms.confluxmap.mc.ui.UiResourceTheme;
 import cn.net.rms.confluxmap.mc.ui.UiTextureRegion;
 import cn.net.rms.confluxmap.mc.ui.WaypointMarkerRenderer;
 import cn.net.rms.confluxmap.mc.ui.screen.FullscreenMapScreen;
+import cn.net.rms.confluxmap.mc.world.ClientChunkLookup;
 import cn.net.rms.confluxmap.mc.world.LayerSelector;
 import java.util.ArrayList;
 import java.util.List;
@@ -181,7 +182,7 @@ public final class MinimapHudRenderer {
             }
             return;
         }
-        final Optional<PlayerView> playerView = gameBridge.player(tickDelta);
+        final Optional<PlayerView> playerView = gameBridge.viewpoint(tickDelta);
         if (playerView.isEmpty()) {
             tiles.clearViewport();
             radarViewRange.set(0);
@@ -623,7 +624,8 @@ public final class MinimapHudRenderer {
     }
 
     private String biomeName(final PlayerView player) {
-        if (client.world == null) {
+        if (client.world == null
+            || !ClientChunkLookup.isLoaded(client.world, player.blockX(), player.blockZ())) {
             return "";
         }
         final Identifier id = Regs.biomeIdAt(

--- a/src/main/java/cn/net/rms/confluxmap/mc/ui/screen/FullscreenMapScreen.java
+++ b/src/main/java/cn/net/rms/confluxmap/mc/ui/screen/FullscreenMapScreen.java
@@ -441,7 +441,7 @@ public final class FullscreenMapScreen extends ConfluxScreen {
         );
 
         final DimensionId dimension = gameBridge.session().dimension();
-        final Optional<PlayerView> player = gameBridge.player();
+        final Optional<PlayerView> player = gameBridge.viewpoint();
         final FullscreenMapViewState.View initialView = viewState.viewForOpening(
             dimension,
             player.isPresent() ? player.get().x() : 0.0,
@@ -2213,7 +2213,7 @@ public final class FullscreenMapScreen extends ConfluxScreen {
         // This screen owns radarViewRange while it's open (MinimapHudRenderer stops writing it -
         // see its render() javadoc).
         final Optional<PlayerView> radarObserver = viewingLiveSession()
-            ? gameBridge.player(tickDelta)
+            ? gameBridge.viewpoint(tickDelta)
             : Optional.empty();
         if (radarObserver.isPresent()) {
             final PlayerView observer = radarObserver.get();
@@ -3306,7 +3306,7 @@ public final class FullscreenMapScreen extends ConfluxScreen {
         if (!viewingLiveSession() || this.client.world == null) {
             return;
         }
-        final Optional<PlayerView> playerView = gameBridge.player(tickDelta);
+        final Optional<PlayerView> playerView = gameBridge.viewpoint(tickDelta);
         if (playerView.isEmpty()) {
             return;
         }


### PR DESCRIPTION
## Summary

- anchor the map view to Minecraft's active camera entity
- fall back to the local player while the camera entity is unavailable
- keep minimap, fullscreen map, markers, and waypoints aligned during detached-camera states

## Verification

- `./gradlew :1.21.1:compileJava :26.2:compileJava --no-daemon`
- launched the Minecraft 1.21.1 test client with Conflux Map 0.1.4-beta.1, Tweakeroo 0.21.61, and MaliLib 0.21.10

Closes #63

## Summary by Sourcery

Align map and radar views with Minecraft’s active camera entity while preserving safe fallback behavior.

New Features:
- Support detached camera entities as the active map viewpoint, with fallback to the local player when unavailable.

Bug Fixes:
- Keep minimap, fullscreen map, markers, waypoints, and radar aligned with the active camera during detached-camera states.
- Prevent biome lookups from using unloaded map chunks.

Enhancements:
- Use the active viewpoint consistently across map rendering and entity radar calculations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved position and rotation tracking by using the active camera when available.
  * Added a fallback to the client player when no camera entity is present.
  * Updated map and radar views to follow the active viewpoint.
  * Preserved existing behavior for missing player or world data and dimension handling.
  * Improved biome display reliability by checking chunk availability before resolving biome names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->