### PR TITLE
feat(waypoint): synchronize map highlight with world view

### DIFF
--- a/src/main/java/cn/net/rms/confluxmap/ConfluxMapClient.java
+++ b/src/main/java/cn/net/rms/confluxmap/ConfluxMapClient.java
@@ -60,6 +60,7 @@ import cn.net.rms.confluxmap.mc.ui.UiResourceTheme;
 import cn.net.rms.confluxmap.mc.ui.screen.FullscreenMapViewState;
 import cn.net.rms.confluxmap.mc.update.UpdateNotifier;
 import cn.net.rms.confluxmap.mc.ui.world.WaypointWorldRenderer;
+import cn.net.rms.confluxmap.mc.ui.world.WaypointHighlightState;
 import cn.net.rms.confluxmap.mc.world.DeathWatcher;
 import cn.net.rms.confluxmap.mc.world.ClientMultiworldService;
 import cn.net.rms.confluxmap.mc.world.LayerSelector;
@@ -114,6 +115,7 @@ public final class ConfluxMapClient implements ClientModInitializer {
     private WaypointRenderCatalog waypointRenderCatalog;
     private DeathWatcher deathWatcher;
     private WaypointWorldRenderer waypointWorldRenderer;
+    private WaypointHighlightState waypointHighlightState;
     private DaylightModel daylightModel;
     private McDaylightTracker daylightTracker;
     private PredictionState predictionState;
@@ -294,6 +296,7 @@ public final class ConfluxMapClient implements ClientModInitializer {
         waypointService = new WaypointService(waypointRoot, executors, ConfluxMapMod.LOGGER);
         annotationService = new AnnotationService(annotationRoot, executors, ConfluxMapMod.LOGGER);
         waypointRenderCatalog = new WaypointRenderCatalog(waypointService, sharedWaypoints::list, config);
+        waypointHighlightState = new WaypointHighlightState();
         deathWatcher = new DeathWatcher(gameBridge, config, waypointService);
         uiResourceTheme = new UiResourceTheme();
         minimapHudRenderer = new MinimapHudRenderer(
@@ -301,7 +304,9 @@ public final class ConfluxMapClient implements ClientModInitializer {
             playerTrail, annotationService, layerSelector, waypointRenderCatalog,
             radarViewRange, uiResourceTheme
         );
-        waypointWorldRenderer = new WaypointWorldRenderer(client, config, gameBridge, waypointRenderCatalog);
+        waypointWorldRenderer = new WaypointWorldRenderer(
+            client, config, gameBridge, waypointRenderCatalog, waypointHighlightState
+        );
         fullscreenMapViewState = new FullscreenMapViewState();
         daylightTracker = new McDaylightTracker(
             client,
@@ -325,6 +330,7 @@ public final class ConfluxMapClient implements ClientModInitializer {
         sessionTracker.addListener(playerTrailTracker::onSessionChanged);
         sessionTracker.addListener(fullscreenMapViewState::onSessionChanged);
         sessionTracker.addListener(waypointService::onSessionChanged);
+        sessionTracker.addListener(waypointHighlightState::onSessionChanged);
         sessionTracker.addListener(annotationService::onSessionChanged);
         sessionTracker.addListener(correctionStore::onSessionChanged);
         sessionTracker.addListener(session -> mapSyncClient.reset());
@@ -522,6 +528,10 @@ public final class ConfluxMapClient implements ClientModInitializer {
 
     public WaypointRenderCatalog waypointRenderCatalog() {
         return waypointRenderCatalog;
+    }
+
+    public WaypointHighlightState waypointHighlightState() {
+        return waypointHighlightState;
     }
 
     public PredictionState predictionState() {

--- a/src/main/java/cn/net/rms/confluxmap/mc/ui/screen/FullscreenMapLocationMenu.java
+++ b/src/main/java/cn/net/rms/confluxmap/mc/ui/screen/FullscreenMapLocationMenu.java
@@ -17,7 +17,9 @@ final class FullscreenMapLocationMenu {
     enum Action {
         SET_WAYPOINT("confluxmap.map.location_menu.set_waypoint"),
         SHARE_LOCATION("confluxmap.map.location_menu.share_location"),
-        TELEPORT("confluxmap.map.location_menu.teleport");
+        TELEPORT("confluxmap.map.location_menu.teleport"),
+        HIGHLIGHT("confluxmap.map.location_menu.highlight"),
+        CLEAR_HIGHLIGHT("confluxmap.map.location_menu.clear_highlight");
 
         private final String translationKey;
 
@@ -34,7 +36,9 @@ final class FullscreenMapLocationMenu {
     private static final List<Action> TELEPORT_FIRST_ACTIONS = List.of(
         Action.TELEPORT,
         Action.SET_WAYPOINT,
-        Action.SHARE_LOCATION
+        Action.SHARE_LOCATION,
+        Action.HIGHLIGHT,
+        Action.CLEAR_HIGHLIGHT
     );
     private static final int PANEL_HEIGHT = PANEL_PADDING * 2
         + DEFAULT_ACTIONS.size() * BUTTON_HEIGHT
@@ -55,6 +59,9 @@ final class FullscreenMapLocationMenu {
     ) {
         if (!playerPresent) {
             return false;
+        }
+        if (action == Action.HIGHLIGHT || action == Action.CLEAR_HIGHLIGHT) {
+            return true;
         }
         return action == Action.TELEPORT ? teleportCommandAvailable : estimatedHeightKnown;
     }

--- a/src/main/java/cn/net/rms/confluxmap/mc/ui/screen/FullscreenMapScreen.java
+++ b/src/main/java/cn/net/rms/confluxmap/mc/ui/screen/FullscreenMapScreen.java
@@ -1907,16 +1907,20 @@ public final class FullscreenMapScreen extends ConfluxScreen {
         switch (action) {
             case HIGHLIGHT -> {
                 if (waypoint != null) {
-                    waypointHighlightState.selectWaypoint(
-                        waypoint, viewSession().dimension()
-                    );
+                    if (SELECTED_LOCATION_ID.equals(waypoint.id())) {
+                        waypointHighlightState.target()
+                            .filter(existing -> existing.waypointId() == null)
+                            .ifPresentOrElse(
+                                waypointHighlightState::select,
+                                () -> selectLocationHighlight(target)
+                            );
+                    } else {
+                        waypointHighlightState.selectWaypoint(
+                            waypoint, viewSession().dimension()
+                        );
+                    }
                 } else if (target != null) {
-                    final boolean yKnown = target.blockY().isPresent();
-                    waypointHighlightState.select(WaypointHighlightState.Target.location(
-                        viewSession().dimension(), target.blockX() + 0.5,
-                        yKnown ? target.blockY().getAsInt() : 0.0,
-                        target.blockZ() + 0.5, yKnown
-                    ));
+                    selectLocationHighlight(target);
                 }
             }
             case CLEAR_HIGHLIGHT -> waypointHighlightState.clear();
@@ -1943,6 +1947,15 @@ public final class FullscreenMapScreen extends ConfluxScreen {
                 );
             }
         }
+    }
+
+    private void selectLocationHighlight(final FullscreenMapLocationMenu.Target target) {
+        final boolean yKnown = target.blockY().isPresent();
+        waypointHighlightState.select(WaypointHighlightState.Target.location(
+            viewSession().dimension(), target.blockX() + 0.5,
+            yKnown ? target.blockY().getAsInt() : WaypointHighlightState.DEFAULT_LOCATION_Y,
+            target.blockZ() + 0.5, yKnown
+        ));
     }
 
     private void shareTemporaryLocation(final FullscreenMapLocationMenu.Target target) {
@@ -3563,7 +3576,9 @@ public final class FullscreenMapScreen extends ConfluxScreen {
         waypointHighlightState.target()
             .filter(target -> target.waypointId() == null && target.dimension().equals(currentDimension))
             .map(target -> new WaypointRenderEntry(
-                SELECTED_LOCATION_ID, "Selected location", currentDimension,
+                SELECTED_LOCATION_ID,
+                Texts.translatable(WaypointHighlightState.SELECTED_LOCATION_TRANSLATION_KEY).getString(),
+                currentDimension,
                 target.x(), target.y(), target.z(), 0xFFFFE066,
                 Waypoint.Type.NORMAL, WaypointRenderEntry.Source.LOCAL
             ))

--- a/src/main/java/cn/net/rms/confluxmap/mc/ui/screen/FullscreenMapScreen.java
+++ b/src/main/java/cn/net/rms/confluxmap/mc/ui/screen/FullscreenMapScreen.java
@@ -87,6 +87,7 @@ import cn.net.rms.confluxmap.mc.ui.DisplayModeIconCatalog;
 import cn.net.rms.confluxmap.mc.ui.PlayerMarkerRenderer;
 import cn.net.rms.confluxmap.mc.ui.PlayerTrailRenderer;
 import cn.net.rms.confluxmap.mc.ui.WaypointMarkerRenderer;
+import cn.net.rms.confluxmap.mc.ui.world.WaypointHighlightState;
 import cn.net.rms.confluxmap.mc.ui.StructureMarkerRenderer;
 import cn.net.rms.confluxmap.mc.world.ClientChunkLookup;
 import cn.net.rms.confluxmap.mc.world.LayerSelector;
@@ -163,6 +164,7 @@ public final class FullscreenMapScreen extends ConfluxScreen {
         }
     }
 
+    private static final UUID SELECTED_LOCATION_ID = new UUID(0x434f4e464c555858L, 0x53454c4543544544L);
     private static final double MIN_SCALE = 0.25;
     private static final double MAX_SCALE = 16.0;
     private static final double DEFAULT_SCALE = 2.0;
@@ -331,6 +333,7 @@ public final class FullscreenMapScreen extends ConfluxScreen {
     private final FullscreenMapBrowseService mapBrowser;
     private final UiResourceTheme uiTheme;
     private InitialFocus initialFocus;
+    private final WaypointHighlightState waypointHighlightState;
 
     /** World point currently at screen center, and blocks-per-pixel; all mutable, panned/zoomed by input. */
     private double centerX;
@@ -368,6 +371,7 @@ public final class FullscreenMapScreen extends ConfluxScreen {
     private int waypointControlsBottom;
     private FullscreenMapLocationMenu.Bounds locationMenuBounds;
     private FullscreenMapLocationMenu.Target locationMenuTarget;
+    private WaypointRenderEntry locationMenuWaypoint;
     private FullscreenMapLocationMenu.Action pendingLocationAction;
     private ButtonWidget setWaypointLocationButton;
     private ButtonWidget shareLocationButton;
@@ -439,6 +443,7 @@ public final class FullscreenMapScreen extends ConfluxScreen {
         this.archivedWaypointRenderCatalog = new WaypointRenderCatalog(
             mapBrowser.waypoints(), List::of, config
         );
+        this.waypointHighlightState = app.waypointHighlightState();
 
         final DimensionId dimension = gameBridge.session().dimension();
         final Optional<PlayerView> player = gameBridge.player();
@@ -465,6 +470,7 @@ public final class FullscreenMapScreen extends ConfluxScreen {
     protected void init() {
         locationMenuBounds = null;
         locationMenuTarget = null;
+        locationMenuWaypoint = null;
         pendingLocationAction = null;
         final InitialFocus requestedFocus = initialFocus;
         if (requestedFocus != null) {
@@ -1492,6 +1498,12 @@ public final class FullscreenMapScreen extends ConfluxScreen {
             if (!viewingLiveWorld() && action == FullscreenMapLocationMenu.Action.SHARE_LOCATION) {
                 button.active = false;
             }
+            if (action == FullscreenMapLocationMenu.Action.HIGHLIGHT) {
+                button.active = viewingLiveSession()
+                    && (locationMenuWaypoint != null || locationMenuTarget != null);
+            } else if (action == FullscreenMapLocationMenu.Action.CLEAR_HIGHLIGHT) {
+                button.active = waypointHighlightState.active();
+            }
             switch (action) {
                 case SET_WAYPOINT -> setWaypointLocationButton = button;
                 case SHARE_LOCATION -> shareLocationButton = button;
@@ -1859,6 +1871,7 @@ public final class FullscreenMapScreen extends ConfluxScreen {
         locationMenuTarget = FullscreenMapLocationMenu.targetAt(
             worldX, surfaceYAt(blockX, blockZ), worldZ
         );
+        locationMenuWaypoint = hoveredWaypoint;
         pendingLocationAction = null;
         mapPointerPress = false;
         rebuildWaypointControls();
@@ -1886,11 +1899,27 @@ public final class FullscreenMapScreen extends ConfluxScreen {
     private void performPendingLocationAction() {
         final FullscreenMapLocationMenu.Action action = pendingLocationAction;
         final FullscreenMapLocationMenu.Target target = locationMenuTarget;
+        final WaypointRenderEntry waypoint = locationMenuWaypoint;
         if (action == null || target == null) {
             return;
         }
         dismissLocationMenu();
         switch (action) {
+            case HIGHLIGHT -> {
+                if (waypoint != null) {
+                    waypointHighlightState.selectWaypoint(
+                        waypoint, viewSession().dimension()
+                    );
+                } else if (target != null) {
+                    final boolean yKnown = target.blockY().isPresent();
+                    waypointHighlightState.select(WaypointHighlightState.Target.location(
+                        viewSession().dimension(), target.blockX() + 0.5,
+                        yKnown ? target.blockY().getAsInt() : 0.0,
+                        target.blockZ() + 0.5, yKnown
+                    ));
+                }
+            }
+            case CLEAR_HIGHLIGHT -> waypointHighlightState.clear();
             case SET_WAYPOINT -> target.blockY().ifPresent(y -> MinecraftAccess.setScreen(MinecraftClient.getInstance(),
                 WaypointEditScreen.forCreate(
                     this,
@@ -1943,6 +1972,7 @@ public final class FullscreenMapScreen extends ConfluxScreen {
     private void dismissLocationMenu() {
         locationMenuBounds = null;
         locationMenuTarget = null;
+        locationMenuWaypoint = null;
         pendingLocationAction = null;
         rebuildWaypointControls();
     }
@@ -3527,7 +3557,18 @@ public final class FullscreenMapScreen extends ConfluxScreen {
         final DimensionId currentDimension = viewSession().dimension();
         final double pxPerBlock = 1.0 / scale;
         final List<ScreenMarker> markers = new ArrayList<>();
-        for (final WaypointRenderEntry waypoint : viewWaypointRenderCatalog().snapshot(currentDimension)) {
+        final List<WaypointRenderEntry> waypoints = new ArrayList<>(
+            viewWaypointRenderCatalog().snapshot(currentDimension)
+        );
+        waypointHighlightState.target()
+            .filter(target -> target.waypointId() == null && target.dimension().equals(currentDimension))
+            .map(target -> new WaypointRenderEntry(
+                SELECTED_LOCATION_ID, "Selected location", currentDimension,
+                target.x(), target.y(), target.z(), 0xFFFFE066,
+                Waypoint.Type.NORMAL, WaypointRenderEntry.Source.LOCAL
+            ))
+            .ifPresent(waypoints::add);
+        for (final WaypointRenderEntry waypoint : waypoints) {
             final float screenX = (float) (width / 2.0 + (waypoint.x() - centerX) * pxPerBlock);
             final float screenY = (float) (height / 2.0 + (waypoint.z() - centerZ) * pxPerBlock);
             if (screenX < -MARKER_HALF_SIZE || screenX > width + MARKER_HALF_SIZE
@@ -3547,16 +3588,19 @@ public final class FullscreenMapScreen extends ConfluxScreen {
             }
         }
         hoveredWaypoint = hovered;
+        final boolean hasHighlight = waypointHighlightState.activeIn(currentDimension);
 
         for (final ScreenMarker marker : markers) {
             final WaypointRenderEntry waypoint = marker.waypoint();
-            final boolean isHovered = waypoint == hoveredWaypoint;
+            final boolean selected = waypointHighlightState.matches(waypoint, currentDimension)
+                || waypointHighlightState.matches(waypoint.x(), waypoint.z(), currentDimension);
+            final boolean isHovered = waypoint == hoveredWaypoint || selected;
             final WaypointVerticalRelation relation = playerView
                 .map(player -> WaypointVerticalRelation.between(waypoint.y(), player.y()))
                 .orElse(WaypointVerticalRelation.NONE);
             WaypointMarkerRenderer.draw(
                 draw, this.client.textRenderer, waypoint, marker.screenX(), marker.screenY(),
-                MARKER_HALF_SIZE, 1f, isHovered, relation
+                MARKER_HALF_SIZE, hasHighlight && !selected ? 0.28f : 1f, isHovered, relation
             );
             if (scale <= NAME_LABEL_MAX_SCALE || isHovered) {
                 draw.drawTextWithShadow(

--- a/src/main/java/cn/net/rms/confluxmap/mc/ui/world/WaypointHighlightState.java
+++ b/src/main/java/cn/net/rms/confluxmap/mc/ui/world/WaypointHighlightState.java
@@ -1,0 +1,82 @@
+package cn.net.rms.confluxmap.mc.ui.world;
+
+import cn.net.rms.confluxmap.core.model.DimensionId;
+import cn.net.rms.confluxmap.core.task.SessionGuard;
+import cn.net.rms.confluxmap.core.waypoint.WaypointRenderEntry;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+/** Client-only selection shared by the fullscreen map and the in-world waypoint HUD. */
+public final class WaypointHighlightState {
+    public record Target(
+        UUID waypointId,
+        DimensionId dimension,
+        double x,
+        double y,
+        double z,
+        boolean yKnown
+    ) {
+        public Target {
+            Objects.requireNonNull(dimension, "dimension");
+        }
+
+        public static Target waypoint(final WaypointRenderEntry waypoint, final DimensionId displayedDimension) {
+            return new Target(waypoint.id(), displayedDimension, waypoint.x(), waypoint.y(), waypoint.z(), true);
+        }
+
+        public static Target location(
+            final DimensionId dimension, final double x, final double y, final double z, final boolean yKnown
+        ) {
+            return new Target(null, dimension, x, y, z, yKnown);
+        }
+    }
+
+    private Target target;
+    private long currentSessionToken = Long.MIN_VALUE;
+
+    public void select(final Target target) {
+        this.target = Objects.requireNonNull(target, "target");
+    }
+
+    public void selectWaypoint(final WaypointRenderEntry waypoint, final DimensionId displayedDimension) {
+        select(Target.waypoint(waypoint, displayedDimension));
+    }
+
+    public void clear() {
+        target = null;
+    }
+
+    public Optional<Target> target() {
+        return Optional.ofNullable(target);
+    }
+
+    public boolean active() {
+        return target != null;
+    }
+
+    public boolean activeIn(final DimensionId dimension) {
+        return target != null && target.dimension().equals(dimension);
+    }
+
+    public boolean matches(final WaypointRenderEntry waypoint, final DimensionId displayedDimension) {
+        return target != null && target.waypointId() != null
+            && target.waypointId().equals(waypoint.id())
+            && target.dimension().equals(displayedDimension);
+    }
+
+    public boolean matches(final double x, final double z, final DimensionId dimension) {
+        return target != null && target.waypointId() == null
+            && target.dimension().equals(dimension)
+            && Math.abs(target.x() - x) < 0.01
+            && Math.abs(target.z() - z) < 0.01;
+    }
+
+    /** Selection is intentionally session-scoped and never leaks across worlds or dimensions. */
+    public void onSessionChanged(final SessionGuard.Session session) {
+        if (!session.active() || currentSessionToken != session.token()) {
+            clear();
+        }
+        currentSessionToken = session.active() ? session.token() : Long.MIN_VALUE;
+    }
+}

--- a/src/main/java/cn/net/rms/confluxmap/mc/ui/world/WaypointHighlightState.java
+++ b/src/main/java/cn/net/rms/confluxmap/mc/ui/world/WaypointHighlightState.java
@@ -9,6 +9,10 @@ import java.util.UUID;
 
 /** Client-only selection shared by the fullscreen map and the in-world waypoint HUD. */
 public final class WaypointHighlightState {
+    public static final String SELECTED_LOCATION_TRANSLATION_KEY =
+        "confluxmap.map.location_menu.selected_location";
+    public static final double DEFAULT_LOCATION_Y = 64.0;
+
     public record Target(
         UUID waypointId,
         DimensionId dimension,

--- a/src/main/java/cn/net/rms/confluxmap/mc/ui/world/WaypointWorldRenderer.java
+++ b/src/main/java/cn/net/rms/confluxmap/mc/ui/world/WaypointWorldRenderer.java
@@ -655,10 +655,6 @@ public final class WaypointWorldRenderer {
     //$$     final Font textRenderer,
     //$$     final FabricOrderedSubmitNodeCollector plates,
     //$$     final FabricOrderedSubmitNodeCollector text,
-    //$$     final WaypointRenderEntry waypoint,
-    //$$     final float halfSize,
-    //$$     final float alpha,
-    //$$     final boolean selected
     //#else
     private static void drawIcon(
         final MatrixStack matrices,

--- a/src/main/java/cn/net/rms/confluxmap/mc/ui/world/WaypointWorldRenderer.java
+++ b/src/main/java/cn/net/rms/confluxmap/mc/ui/world/WaypointWorldRenderer.java
@@ -8,11 +8,13 @@ import cn.net.rms.confluxmap.core.model.DimensionId;
 import cn.net.rms.confluxmap.core.util.Argb;
 import cn.net.rms.confluxmap.core.waypoint.WaypointRenderCatalog;
 import cn.net.rms.confluxmap.core.waypoint.WaypointRenderEntry;
+import cn.net.rms.confluxmap.core.waypoint.Waypoint;
 import cn.net.rms.confluxmap.mc.render.RenderUtil;
 import cn.net.rms.confluxmap.mc.ui.WaypointMarkerRenderer;
 import com.mojang.blaze3d.systems.RenderSystem;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -78,6 +80,8 @@ import net.minecraft.util.math.Vec3d;
  * (when non-zero) can only tighten that limit, never extend it.
  */
 public final class WaypointWorldRenderer {
+    private static final UUID SELECTED_LOCATION_ID = new UUID(0x434f4e464c555858L, 0x53454c4543544544L);
+    private static final int SELECTED_LOCATION_COLOR = 0xFFFFE066;
     private static final double BEAM_HALF_WIDTH = 0.18;
     private static final float BEAM_CORE_ALPHA = 0.55f;
     /** Same near-camera fade-in constant as the label (waypoint-ux.md S6), applied to horizontal distance from the beam column. */
@@ -110,6 +114,7 @@ public final class WaypointWorldRenderer {
     private final ConfluxConfig config;
     private final GameBridge gameBridge;
     private final WaypointRenderCatalog waypointRenderCatalog;
+    private final WaypointHighlightState waypointHighlightState;
     private final Map<UUID, Float> labelAnimationProgress = new HashMap<>();
     private long lastAnimationNanos;
 
@@ -117,12 +122,14 @@ public final class WaypointWorldRenderer {
         final MinecraftClient client,
         final ConfluxConfig config,
         final GameBridge gameBridge,
-        final WaypointRenderCatalog waypointRenderCatalog
+        final WaypointRenderCatalog waypointRenderCatalog,
+        final WaypointHighlightState waypointHighlightState
     ) {
         this.client = client;
         this.config = config;
         this.gameBridge = gameBridge;
         this.waypointRenderCatalog = waypointRenderCatalog;
+        this.waypointHighlightState = waypointHighlightState;
     }
 
     //#if MC>=12109 && MC<12111
@@ -217,7 +224,8 @@ public final class WaypointWorldRenderer {
         final double maxDistance = maxVisibleDistance();
         final double bottomY = client.world.getBottomY();
         final double topY = client.world.getTopY();
-        final List<WaypointRenderEntry> waypoints = waypointRenderCatalog.snapshot(currentDimension);
+        final List<WaypointRenderEntry> waypoints = new ArrayList<>(waypointRenderCatalog.snapshot(currentDimension));
+        selectedTargetEntry(currentDimension).ifPresent(waypoints::add);
 
         //#if MC<12105
         RenderSystem.enableDepthTest();
@@ -237,9 +245,12 @@ public final class WaypointWorldRenderer {
                 continue;
             }
             final double horizontalDistance = Math.sqrt(dx * dx + dz * dz);
+            final boolean selected = waypointHighlightState.matches(waypoint, currentDimension)
+                || waypointHighlightState.matches(waypoint.x(), waypoint.z(), currentDimension);
             drawBeam(
                 matrices, cameraPos, worldX, worldZ, bottomY, topY,
-                waypoint.colorArgb(), horizontalDistance, maxDistance
+                waypoint.colorArgb(), horizontalDistance, maxDistance,
+                selected ? 1f : waypointHighlightState.activeIn(currentDimension) ? 0.28f : 1f
             );
         }
 
@@ -305,7 +316,8 @@ public final class WaypointWorldRenderer {
         final MatrixStack matrices = context.matrixStack();
         //#endif
         final double maxDistance = maxVisibleDistance();
-        final List<WaypointRenderEntry> waypoints = waypointRenderCatalog.snapshot(currentDimension);
+        final List<WaypointRenderEntry> waypoints = new ArrayList<>(waypointRenderCatalog.snapshot(currentDimension));
+        selectedTargetEntry(currentDimension).ifPresent(waypoints::add);
         final WaypointRenderEntry targetedWaypoint = targetedWaypoint(
             waypoints, cameraYaw, cameraPitch, cameraPos, maxDistance
         );
@@ -343,18 +355,23 @@ public final class WaypointWorldRenderer {
                     final double dy = waypoint.y() - player.y();
                     final double dz = waypoint.z() - player.z();
                     final double distance3d = Math.sqrt(dx * dx + dy * dy + dz * dz);
-                    final boolean targeted = targetedWaypoint != null && targetedWaypoint.id().equals(waypoint.id());
+                    final boolean selected = waypointHighlightState.matches(waypoint, currentDimension)
+                        || waypointHighlightState.matches(waypoint.x(), waypoint.z(), currentDimension);
+                    final boolean targeted = selected
+                        || targetedWaypoint != null && targetedWaypoint.id().equals(waypoint.id());
                     final float progress = updateLabelAnimation(waypoint.id(), targeted, animationDeltaSeconds);
                     //#if MC>=260200
                     //$$ drawLabel(
                     //$$     matrices, context.submitNodeCollector(), cameraState.orientation,
                     //$$     cameraPos, waypoint.x(), waypoint.y(), waypoint.z(), waypoint,
-                    //$$     distance3d, progress
+                    //$$     distance3d, progress,
+                    //$$     selected ? 1f : waypointHighlightState.activeIn(currentDimension) ? 0.28f : 1f
                     //$$ );
                     //#else
                     drawLabel(
                         matrices, immediate, camera, cameraPos, waypoint.x(), waypoint.y(), waypoint.z(),
-                        waypoint, distance3d, progress
+                        waypoint, distance3d, progress,
+                        selected ? 1f : waypointHighlightState.activeIn(currentDimension) ? 0.28f : 1f
                     );
                     //#endif
                 }
@@ -386,6 +403,17 @@ public final class WaypointWorldRenderer {
         return config.waypointRenderDistance > 0
             ? Math.min(config.waypointRenderDistance, viewDistanceBlocks)
             : viewDistanceBlocks;
+    }
+
+    private Optional<WaypointRenderEntry> selectedTargetEntry(final DimensionId dimension) {
+        return waypointHighlightState.target()
+            .filter(target -> target.waypointId() == null && target.dimension().equals(dimension))
+            .map(target -> new WaypointRenderEntry(
+                SELECTED_LOCATION_ID, "Selected location", dimension,
+                target.x(), target.y(), target.z(), SELECTED_LOCATION_COLOR,
+                Waypoint.Type.NORMAL,
+                WaypointRenderEntry.Source.LOCAL
+            ));
     }
 
     private WaypointRenderEntry targetedWaypoint(
@@ -460,12 +488,13 @@ public final class WaypointWorldRenderer {
         final double topY,
         final int colorArgb,
         final double horizontalDistance,
-        final double maxDistance
+        final double maxDistance,
+        final float visibilityAlpha
     ) {
         final float nearFade = (float) MathHelper.clamp(horizontalDistance / BEAM_NEAR_FADE_BLOCKS, 0.0, 1.0);
         final float farFactor = (float) MathHelper.clamp(1.0 - horizontalDistance / maxDistance, 0.0, 1.0);
         final float intensify = BEAM_FAR_FLOOR + (1f - BEAM_FAR_FLOOR) * farFactor;
-        final float alpha = BEAM_CORE_ALPHA * nearFade * intensify;
+        final float alpha = BEAM_CORE_ALPHA * nearFade * intensify * visibilityAlpha;
         if (alpha <= 0.01f) {
             return;
         }
@@ -513,7 +542,8 @@ public final class WaypointWorldRenderer {
         final double worldZ,
         final WaypointRenderEntry waypoint,
         final double distance3d,
-        final float animationProgress
+        final float animationProgress,
+        final float visibilityAlpha
     ) {
         final float nearFade = (float) MathHelper.clamp(distance3d / LABEL_NEAR_FADE_BLOCKS, 0.0, 1.0);
         if (nearFade <= 0.01f) {
@@ -565,24 +595,28 @@ public final class WaypointWorldRenderer {
             //#if MC>=260200
             //$$ submitRect(
             //$$     plates, matrices, panelX, -LABEL_PANEL_HEIGHT / 2f,
-            //$$     panelWidth, LABEL_PANEL_HEIGHT, withAlpha(LABEL_BACKGROUND_COLOR, nearFade)
+            //$$     panelWidth, LABEL_PANEL_HEIGHT, withAlpha(LABEL_BACKGROUND_COLOR, nearFade * visibilityAlpha)
             //$$ );
             //#else
             RenderUtil.fillRect3D(
                 matrices, panelX, -LABEL_PANEL_HEIGHT / 2f,
-                panelWidth, LABEL_PANEL_HEIGHT, withAlpha(LABEL_BACKGROUND_COLOR, nearFade)
+                panelWidth, LABEL_PANEL_HEIGHT, withAlpha(LABEL_BACKGROUND_COLOR, nearFade * visibilityAlpha)
             );
             //#endif
         }
         //#if MC>=260200
         //$$ drawIcon(
         //$$     matrices, textRenderer, plates, text, waypoint, iconHalfSize,
-        //$$     nearFade * config.waypointIconOpacity / (float) ConfluxConfig.MAX_WAYPOINT_ICON_OPACITY
+        //$$     nearFade * config.waypointIconOpacity
+        //$$         / (float) ConfluxConfig.MAX_WAYPOINT_ICON_OPACITY * visibilityAlpha,
+        //$$     visibilityAlpha >= 1f
         //$$ );
         //#else
         drawIcon(
             matrices, textRenderer, immediate, waypoint, iconHalfSize,
-            nearFade * config.waypointIconOpacity / (float) ConfluxConfig.MAX_WAYPOINT_ICON_OPACITY
+            nearFade * config.waypointIconOpacity
+                / (float) ConfluxConfig.MAX_WAYPOINT_ICON_OPACITY * visibilityAlpha,
+            visibilityAlpha >= 1f
         );
         //#endif
 
@@ -591,7 +625,7 @@ public final class WaypointWorldRenderer {
         );
         if (textReveal > 0.01f) {
             final float textX = panelX + LABEL_PANEL_PADDING + (1f - textReveal) * 4f;
-            final float textAlpha = nearFade * textReveal;
+            final float textAlpha = nearFade * textReveal * visibilityAlpha;
             //#if MC>=260200
             //$$ submitText(
             //$$     text, matrices, name, textX, -9f,
@@ -621,6 +655,10 @@ public final class WaypointWorldRenderer {
     //$$     final Font textRenderer,
     //$$     final FabricOrderedSubmitNodeCollector plates,
     //$$     final FabricOrderedSubmitNodeCollector text,
+    //$$     final WaypointRenderEntry waypoint,
+    //$$     final float halfSize,
+    //$$     final float alpha,
+    //$$     final boolean selected
     //#else
     private static void drawIcon(
         final MatrixStack matrices,
@@ -629,13 +667,14 @@ public final class WaypointWorldRenderer {
     //#endif
         final WaypointRenderEntry waypoint,
         final float halfSize,
-        final float alpha
+        final float alpha,
+        final boolean selected
     ) {
         final float size = halfSize * 2f;
         //#if MC>=260200
         //$$ submitRect(
         //$$     plates, matrices, -halfSize - 1f, -halfSize - 1f, size + 2f, size + 2f,
-        //$$     withAlpha(outlineColor(waypoint), alpha)
+        //$$     withAlpha(selected ? 0xFFFFE066 : outlineColor(waypoint), alpha)
         //$$ );
         //$$ submitRect(
         //$$     plates, matrices, -halfSize, -halfSize, size, size,
@@ -644,7 +683,7 @@ public final class WaypointWorldRenderer {
         //#else
         RenderUtil.fillRect3D(
             matrices, -halfSize - 1f, -halfSize - 1f, size + 2f, size + 2f,
-            withAlpha(outlineColor(waypoint), alpha)
+            withAlpha(selected ? 0xFFFFE066 : outlineColor(waypoint), alpha)
         );
         RenderUtil.fillRect3D(
             matrices, -halfSize, -halfSize, size, size,

--- a/src/main/java/cn/net/rms/confluxmap/mc/ui/world/WaypointWorldRenderer.java
+++ b/src/main/java/cn/net/rms/confluxmap/mc/ui/world/WaypointWorldRenderer.java
@@ -3,6 +3,7 @@ package cn.net.rms.confluxmap.mc.ui.world;
 import cn.net.rms.confluxmap.bridge.GameBridge;
 import cn.net.rms.confluxmap.bridge.PlayerView;
 import cn.net.rms.confluxmap.compat.MinecraftAccess;
+import cn.net.rms.confluxmap.compat.Texts;
 import cn.net.rms.confluxmap.core.config.ConfluxConfig;
 import cn.net.rms.confluxmap.core.model.DimensionId;
 import cn.net.rms.confluxmap.core.util.Argb;
@@ -365,13 +366,15 @@ public final class WaypointWorldRenderer {
                     //$$     matrices, context.submitNodeCollector(), cameraState.orientation,
                     //$$     cameraPos, waypoint.x(), waypoint.y(), waypoint.z(), waypoint,
                     //$$     distance3d, progress,
-                    //$$     selected ? 1f : waypointHighlightState.activeIn(currentDimension) ? 0.28f : 1f
+                    //$$     selected ? 1f : waypointHighlightState.activeIn(currentDimension) ? 0.28f : 1f,
+                    //$$     selected
                     //$$ );
                     //#else
                     drawLabel(
                         matrices, immediate, camera, cameraPos, waypoint.x(), waypoint.y(), waypoint.z(),
                         waypoint, distance3d, progress,
-                        selected ? 1f : waypointHighlightState.activeIn(currentDimension) ? 0.28f : 1f
+                        selected ? 1f : waypointHighlightState.activeIn(currentDimension) ? 0.28f : 1f,
+                        selected
                     );
                     //#endif
                 }
@@ -409,11 +412,18 @@ public final class WaypointWorldRenderer {
         return waypointHighlightState.target()
             .filter(target -> target.waypointId() == null && target.dimension().equals(dimension))
             .map(target -> new WaypointRenderEntry(
-                SELECTED_LOCATION_ID, "Selected location", dimension,
-                target.x(), target.y(), target.z(), SELECTED_LOCATION_COLOR,
+                SELECTED_LOCATION_ID,
+                Texts.translatable(WaypointHighlightState.SELECTED_LOCATION_TRANSLATION_KEY).getString(),
+                dimension,
+                target.x(), selectedLocationY(target), target.z(), SELECTED_LOCATION_COLOR,
                 Waypoint.Type.NORMAL,
                 WaypointRenderEntry.Source.LOCAL
             ));
+    }
+
+    private double selectedLocationY(final WaypointHighlightState.Target target) {
+        final double y = target.yKnown() ? target.y() : WaypointHighlightState.DEFAULT_LOCATION_Y;
+        return MathHelper.clamp(y, client.world.getBottomY(), client.world.getTopY() - 1.0);
     }
 
     private WaypointRenderEntry targetedWaypoint(
@@ -543,7 +553,8 @@ public final class WaypointWorldRenderer {
         final WaypointRenderEntry waypoint,
         final double distance3d,
         final float animationProgress,
-        final float visibilityAlpha
+        final float visibilityAlpha,
+        final boolean selected
     ) {
         final float nearFade = (float) MathHelper.clamp(distance3d / LABEL_NEAR_FADE_BLOCKS, 0.0, 1.0);
         if (nearFade <= 0.01f) {
@@ -609,14 +620,14 @@ public final class WaypointWorldRenderer {
         //$$     matrices, textRenderer, plates, text, waypoint, iconHalfSize,
         //$$     nearFade * config.waypointIconOpacity
         //$$         / (float) ConfluxConfig.MAX_WAYPOINT_ICON_OPACITY * visibilityAlpha,
-        //$$     visibilityAlpha >= 1f
+        //$$     selected
         //$$ );
         //#else
         drawIcon(
             matrices, textRenderer, immediate, waypoint, iconHalfSize,
             nearFade * config.waypointIconOpacity
                 / (float) ConfluxConfig.MAX_WAYPOINT_ICON_OPACITY * visibilityAlpha,
-            visibilityAlpha >= 1f
+            selected
         );
         //#endif
 

--- a/src/main/resources/assets/confluxmap/lang/en_us.json
+++ b/src/main/resources/assets/confluxmap/lang/en_us.json
@@ -154,6 +154,8 @@
   "confluxmap.map.location_menu.set_waypoint": "Set Waypoint",
   "confluxmap.map.location_menu.share_location": "Share Location",
   "confluxmap.map.location_menu.teleport": "Teleport Here",
+  "confluxmap.map.location_menu.highlight": "Set Navigation Target",
+  "confluxmap.map.location_menu.clear_highlight": "Clear Navigation Target",
   "confluxmap.map.location_menu.temporary_name": "Shared Location",
   "confluxmap.map.location_menu.height_unavailable": "Surface height is unavailable at this location.",
   "confluxmap.map.location_menu.teleport_unavailable": "The teleport command is unavailable.",

--- a/src/main/resources/assets/confluxmap/lang/en_us.json
+++ b/src/main/resources/assets/confluxmap/lang/en_us.json
@@ -156,6 +156,7 @@
   "confluxmap.map.location_menu.teleport": "Teleport Here",
   "confluxmap.map.location_menu.highlight": "Set Navigation Target",
   "confluxmap.map.location_menu.clear_highlight": "Clear Navigation Target",
+  "confluxmap.map.location_menu.selected_location": "Selected location",
   "confluxmap.map.location_menu.temporary_name": "Shared Location",
   "confluxmap.map.location_menu.height_unavailable": "Surface height is unavailable at this location.",
   "confluxmap.map.location_menu.teleport_unavailable": "The teleport command is unavailable.",

--- a/src/main/resources/assets/confluxmap/lang/zh_cn.json
+++ b/src/main/resources/assets/confluxmap/lang/zh_cn.json
@@ -154,6 +154,8 @@
   "confluxmap.map.location_menu.set_waypoint": "设置路径点",
   "confluxmap.map.location_menu.share_location": "分享位置",
   "confluxmap.map.location_menu.teleport": "传送到此处",
+  "confluxmap.map.location_menu.highlight": "设为导航目标",
+  "confluxmap.map.location_menu.clear_highlight": "取消导航目标",
   "confluxmap.map.location_menu.temporary_name": "共享位置",
   "confluxmap.map.location_menu.height_unavailable": "无法确定此处的地表高度。",
   "confluxmap.map.location_menu.teleport_unavailable": "当前无法使用传送命令。",

--- a/src/main/resources/assets/confluxmap/lang/zh_cn.json
+++ b/src/main/resources/assets/confluxmap/lang/zh_cn.json
@@ -156,6 +156,7 @@
   "confluxmap.map.location_menu.teleport": "传送到此处",
   "confluxmap.map.location_menu.highlight": "设为导航目标",
   "confluxmap.map.location_menu.clear_highlight": "取消导航目标",
+  "confluxmap.map.location_menu.selected_location": "选中位置",
   "confluxmap.map.location_menu.temporary_name": "共享位置",
   "confluxmap.map.location_menu.height_unavailable": "无法确定此处的地表高度。",
   "confluxmap.map.location_menu.teleport_unavailable": "当前无法使用传送命令。",

--- a/src/test/java/cn/net/rms/confluxmap/mc/ui/screen/FullscreenMapLocationMenuTest.java
+++ b/src/test/java/cn/net/rms/confluxmap/mc/ui/screen/FullscreenMapLocationMenuTest.java
@@ -16,7 +16,9 @@ class FullscreenMapLocationMenuTest {
         assertEquals(List.of(
             FullscreenMapLocationMenu.Action.SET_WAYPOINT,
             FullscreenMapLocationMenu.Action.SHARE_LOCATION,
-            FullscreenMapLocationMenu.Action.TELEPORT
+            FullscreenMapLocationMenu.Action.TELEPORT,
+            FullscreenMapLocationMenu.Action.HIGHLIGHT,
+            FullscreenMapLocationMenu.Action.CLEAR_HIGHLIGHT
         ), FullscreenMapLocationMenu.actions(false));
     }
 
@@ -25,7 +27,9 @@ class FullscreenMapLocationMenuTest {
         assertEquals(List.of(
             FullscreenMapLocationMenu.Action.TELEPORT,
             FullscreenMapLocationMenu.Action.SET_WAYPOINT,
-            FullscreenMapLocationMenu.Action.SHARE_LOCATION
+            FullscreenMapLocationMenu.Action.SHARE_LOCATION,
+            FullscreenMapLocationMenu.Action.HIGHLIGHT,
+            FullscreenMapLocationMenu.Action.CLEAR_HIGHLIGHT
         ), FullscreenMapLocationMenu.actions(true));
     }
 

--- a/src/test/java/cn/net/rms/confluxmap/mc/ui/world/WaypointHighlightStateTest.java
+++ b/src/test/java/cn/net/rms/confluxmap/mc/ui/world/WaypointHighlightStateTest.java
@@ -1,0 +1,55 @@
+package cn.net.rms.confluxmap.mc.ui.world;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import cn.net.rms.confluxmap.core.model.DimensionId;
+import cn.net.rms.confluxmap.core.model.WorldIdentity;
+import cn.net.rms.confluxmap.core.task.SessionGuard;
+import org.junit.jupiter.api.Test;
+
+class WaypointHighlightStateTest {
+    private static final WorldIdentity WORLD = WorldIdentity.singleplayer("highlight-test");
+
+    @Test
+    void temporaryLocationMatchesOnlyItsDimensionAndCoordinates() {
+        final WaypointHighlightState state = new WaypointHighlightState();
+        state.select(WaypointHighlightState.Target.location(
+            DimensionId.OVERWORLD, 10.5, 64.0, -20.5, true
+        ));
+
+        assertTrue(state.activeIn(DimensionId.OVERWORLD));
+        assertTrue(state.matches(10.5, -20.5, DimensionId.OVERWORLD));
+        assertFalse(state.matches(10.5, -20.5, DimensionId.NETHER));
+        assertFalse(state.matches(11.5, -20.5, DimensionId.OVERWORLD));
+    }
+
+    @Test
+    void sessionChangeClearsTheSelection() {
+        final WaypointHighlightState state = new WaypointHighlightState();
+        state.onSessionChanged(new SessionGuard.Session(1L, WORLD, DimensionId.OVERWORLD));
+        state.select(WaypointHighlightState.Target.location(
+            DimensionId.OVERWORLD, 10.5, 64.0, -20.5, true
+        ));
+
+        state.onSessionChanged(new SessionGuard.Session(2L, WORLD, DimensionId.NETHER));
+
+        assertFalse(state.active());
+    }
+
+    @Test
+    void repeatedNotificationForTheSameSessionKeepsTheSelection() {
+        final WaypointHighlightState state = new WaypointHighlightState();
+        final SessionGuard.Session session = new SessionGuard.Session(
+            1L, WORLD, DimensionId.OVERWORLD
+        );
+        state.onSessionChanged(session);
+        state.select(WaypointHighlightState.Target.location(
+            DimensionId.OVERWORLD, 10.5, 64.0, -20.5, true
+        ));
+
+        state.onSessionChanged(session);
+
+        assertTrue(state.active());
+    }
+}


### PR DESCRIPTION
## Summary
- add fullscreen-map context menu actions to set or clear a navigation target for waypoints and arbitrary map locations
- share session-scoped highlight state with the in-world waypoint renderer and reduce non-target marker, label, and beam opacity
- preserve waypoint icon opacity settings, clear highlights across session/dimension changes, and add English/Chinese translations
- add coverage for context-menu ordering and highlight-state matching/lifecycle

## Testing
- `./gradlew.bat :1.21.1:test --tests "cn.net.rms.confluxmap.mc.ui.screen.FullscreenMapLocationMenuTest" --tests "cn.net.rms.confluxmap.mc.ui.world.WaypointHighlightStateTest" -x :common:test --no-daemon`
- launched `./gradlew.bat :1.21.1:runClient --no-daemon` and confirmed Conflux Map client services/resource loading
- validated `en_us.json` and `zh_cn.json` with PowerShell `ConvertFrom-Json`
- `git diff --check`

Closes #62

## Summary by Sourcery

Synchronize fullscreen-map waypoint highlighting with the in-world waypoint display and support selecting or clearing navigation targets.

New Features:
- Add fullscreen-map actions for highlighting and clearing highlights on waypoints or arbitrary locations.
- Synchronize the selected location with in-world waypoint rendering.

Bug Fixes:
- Clear highlight selections when the client session changes to prevent stale cross-world or cross-dimension state.
- Preserve configured waypoint icon opacity while dimming non-selected markers, labels, and beams.

Enhancements:
- Provide localized labels for selected locations and highlight actions in English and Chinese.
- Cover location-menu ordering and highlight matching and lifecycle behavior.

Tests:
- Add tests for highlight-state coordinate and dimension matching, session lifecycle, and location-menu action ordering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Highlight a waypoint or map location as a navigation target from the fullscreen map.
  - Clear the active navigation target directly from the location menu.
  - Highlighted targets appear prominently in the in-world waypoint display, while unrelated markers are dimmed.
  - Coordinate-only targets appear as selected map markers with dimension-aware matching and sensible height handling.

- **Localization**
  - Added English and Chinese translations for navigation-target actions and selected locations.

- **Bug Fixes**
  - Navigation highlights now reset when the map session changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- conflux-agent:links:start -->
Closes #62
<!-- conflux-agent:links:end -->