### PR TITLE
fix(waypoints): keep distant labels visible

### DIFF
--- a/docs/reference-specs/waypoint-ux.md
+++ b/docs/reference-specs/waypoint-ux.md
@@ -473,12 +473,16 @@ through it). Notable rendering rules:
   (3-D straight-line, in blocks; "off"/infinite is a valid setting) beyond
   which a sign is not rendered at all (not faded, not clamped — simply
   skipped), *except* for the one currently-highlighted/"pinged" waypoint,
-  which always renders regardless of distance. **This cutoff applies only
-  to the floating sign layer — the vertical beam layer has no distance
-  cutoff of its own** and is limited only by the game's ordinary render
-  distance. This is a real asymmetry in the reference implementation, not
-  an oversight worth "fixing" silently — decide deliberately whether our
-  beam layer should share the sign layer's cutoff or stay unbounded.
+  which always renders regardless of distance. The configured value is used
+  as the actual cutoff; when it is off, labels have no distance cutoff. Far
+  labels are projected inside the camera's far plane along the same sight
+  line, so they remain visible and show their real distance even after the
+  waypoint's world geometry is clipped. **This cutoff applies only to the
+  floating sign layer — the vertical beam layer has no distance cutoff of
+  its own** and is limited only by the game's ordinary render distance. This
+  is a real asymmetry in the reference implementation, not an oversight
+  worth "fixing" silently — decide deliberately whether our beam layer
+  should share the sign layer's cutoff or stay unbounded.
 - **Toggles are global** (beam on/off, sign on/off), not per-waypoint —
   an individual waypoint has no "show my beam but not my sign" flag of
   its own, only the overall enabled/visibility flag from §1.

--- a/src/main/java/cn/net/rms/confluxmap/mc/ui/world/WaypointWorldRenderer.java
+++ b/src/main/java/cn/net/rms/confluxmap/mc/ui/world/WaypointWorldRenderer.java
@@ -72,10 +72,10 @@ import net.minecraft.util.math.Vec3d;
  * {@code client.getBufferBuilders().getEntityVertexConsumers()}) which works at any
  * phase and is flushed once at the end of this render pass.
  *
- * <p>Both the beam and the HUD label are proximity-gated: they only render for waypoints
- * within the player's current view distance, so far-away waypoints have no in-world
- * presence until the player travels toward them. {@code config.waypointRenderDistance}
- * (when non-zero) can only tighten that limit, never extend it.
+ * <p>The beam and HUD label have deliberately separate distance rules. Beam geometry only
+ * exists inside the vanilla view distance. Labels use {@code config.waypointRenderDistance}
+ * as their cutoff, including its unlimited mode, and far labels are pulled inside the camera's
+ * far plane along the same sight line so they remain visible after their beam disappears.
  */
 public final class WaypointWorldRenderer {
     private static final double BEAM_HALF_WIDTH = 0.18;
@@ -98,6 +98,8 @@ public final class WaypointWorldRenderer {
     private static final float LABEL_PANEL_PADDING = 3.0f;
     private static final float LABEL_PANEL_GAP = 1.0f;
     private static final float LABEL_TEXT_REVEAL_START = 0.72f;
+    /** Leaves enough room before the world projection's far plane for the complete billboard. */
+    private static final double LABEL_FAR_PLANE_MARGIN = 0.90;
     private static final int LABEL_BACKGROUND_COLOR = 0xC0101010;
     private static final int LABEL_LOCAL_OUTLINE_COLOR = 0xFF101010;
     private static final int LABEL_SHARED_OUTLINE_COLOR = 0xFF55DDE0;
@@ -214,7 +216,10 @@ public final class WaypointWorldRenderer {
         final Vec3d cameraPos = camera.getPos();
         final MatrixStack matrices = context.matrixStack();
         //#endif
-        final double maxDistance = maxVisibleDistance();
+        final double maxDistance = beamVisibleDistance(MinecraftAccess.viewDistance(client));
+        if (maxDistance <= 0.0) {
+            return;
+        }
         final double bottomY = client.world.getBottomY();
         final double topY = client.world.getTopY();
         final List<WaypointRenderEntry> waypoints = waypointRenderCatalog.snapshot(currentDimension);
@@ -304,7 +309,10 @@ public final class WaypointWorldRenderer {
         final float cameraPitch = camera.getPitch();
         final MatrixStack matrices = context.matrixStack();
         //#endif
-        final double maxDistance = maxVisibleDistance();
+        final double maxDistance = maxLabelDistance(config.waypointRenderDistance);
+        final double labelProjectionDistance = labelProjectionDistance(
+            MinecraftAccess.viewDistance(client)
+        );
         final List<WaypointRenderEntry> waypoints = waypointRenderCatalog.snapshot(currentDimension);
         final WaypointRenderEntry targetedWaypoint = targetedWaypoint(
             waypoints, cameraYaw, cameraPitch, cameraPos, maxDistance
@@ -349,12 +357,12 @@ public final class WaypointWorldRenderer {
                     //$$ drawLabel(
                     //$$     matrices, context.submitNodeCollector(), cameraState.orientation,
                     //$$     cameraPos, waypoint.x(), waypoint.y(), waypoint.z(), waypoint,
-                    //$$     distance3d, progress
+                    //$$     distance3d, labelProjectionDistance, progress
                     //$$ );
                     //#else
                     drawLabel(
                         matrices, immediate, camera, cameraPos, waypoint.x(), waypoint.y(), waypoint.z(),
-                        waypoint, distance3d, progress
+                        waypoint, distance3d, labelProjectionDistance, progress
                     );
                     //#endif
                 }
@@ -375,17 +383,23 @@ public final class WaypointWorldRenderer {
         labelAnimationProgress.keySet().retainAll(visibleWaypointIds);
     }
 
-    /**
-     * Beams and labels only appear once the player is near the waypoint, where "near"
-     * means within the current view distance (chunks converted to blocks). A non-zero
-     * {@code config.waypointRenderDistance} can tighten the limit but never extend it
-     * past what the player can actually see.
-     */
-    private double maxVisibleDistance() {
-        final double viewDistanceBlocks = MinecraftAccess.viewDistance(client) * 16.0;
-        return config.waypointRenderDistance > 0
-            ? Math.min(config.waypointRenderDistance, viewDistanceBlocks)
-            : viewDistanceBlocks;
+    static double maxLabelDistance(final int configuredDistance) {
+        return configuredDistance > 0 ? configuredDistance : Double.POSITIVE_INFINITY;
+    }
+
+    static double beamVisibleDistance(final int viewDistanceChunks) {
+        return Math.max(0, viewDistanceChunks) * 16.0;
+    }
+
+    static double labelProjectionDistance(final int viewDistanceChunks) {
+        return Math.max(16.0, beamVisibleDistance(viewDistanceChunks) * LABEL_FAR_PLANE_MARGIN);
+    }
+
+    static double projectedLabelDistance(
+        final double actualDistance,
+        final double projectionDistance
+    ) {
+        return Math.min(Math.max(0.0, actualDistance), Math.max(0.0, projectionDistance));
     }
 
     private WaypointRenderEntry targetedWaypoint(
@@ -513,15 +527,27 @@ public final class WaypointWorldRenderer {
         final double worldZ,
         final WaypointRenderEntry waypoint,
         final double distance3d,
+        final double projectionDistance,
         final float animationProgress
     ) {
         final float nearFade = (float) MathHelper.clamp(distance3d / LABEL_NEAR_FADE_BLOCKS, 0.0, 1.0);
         if (nearFade <= 0.01f) {
             return;
         }
-        // Scale proportionally with distance so the marker keeps a useful apparent size on screen.
+        final double anchorX = worldX - cameraPos.x;
+        final double anchorY = worldY + LABEL_Y_OFFSET - cameraPos.y;
+        final double anchorZ = worldZ - cameraPos.z;
+        final double anchorDistance = Math.sqrt(
+            anchorX * anchorX + anchorY * anchorY + anchorZ * anchorZ
+        );
+        final double renderedDistance = projectedLabelDistance(anchorDistance, projectionDistance);
+        final double projectionScale = anchorDistance > 0.001
+            ? renderedDistance / anchorDistance
+            : 1.0;
+
+        // Scale against the projected distance so pulling a far marker closer does not enlarge it.
         final float scaleMult = (float) MathHelper.clamp(
-            distance3d / LABEL_REFERENCE_DISTANCE, LABEL_MIN_SCALE_MULT, LABEL_MAX_SCALE_MULT
+            renderedDistance / LABEL_REFERENCE_DISTANCE, LABEL_MIN_SCALE_MULT, LABEL_MAX_SCALE_MULT
         );
         // Applied last so the user factor is a plain multiplier on apparent size at every distance.
         final float scale = LABEL_BASE_SCALE * scaleMult * config.waypointLabelScalePercent / 100f;
@@ -542,7 +568,11 @@ public final class WaypointWorldRenderer {
         final float panelWidth = panelFullWidth * panelReveal;
 
         matrices.push();
-        matrices.translate(worldX - cameraPos.x, worldY + LABEL_Y_OFFSET - cameraPos.y, worldZ - cameraPos.z);
+        matrices.translate(
+            anchorX * projectionScale,
+            anchorY * projectionScale,
+            anchorZ * projectionScale
+        );
         //#if MC>=260200
         //$$ matrices.mulPose(cameraRotation);
         //#else

--- a/src/test/java/cn/net/rms/confluxmap/mc/ui/world/WaypointWorldRendererDistanceTest.java
+++ b/src/test/java/cn/net/rms/confluxmap/mc/ui/world/WaypointWorldRendererDistanceTest.java
@@ -1,0 +1,47 @@
+package cn.net.rms.confluxmap.mc.ui.world;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+final class WaypointWorldRendererDistanceTest {
+    @Test
+    void configuredDistanceIsNotCappedByVanillaViewDistance() {
+        assertEquals(512.0, WaypointWorldRenderer.maxLabelDistance(512));
+    }
+
+    @Test
+    void zeroConfiguredDistanceLeavesLabelsUnlimited() {
+        assertEquals(
+            Double.POSITIVE_INFINITY,
+            WaypointWorldRenderer.maxLabelDistance(0)
+        );
+    }
+
+    @Test
+    void beamDistanceStillFollowsVanillaViewDistance() {
+        assertEquals(128.0, WaypointWorldRenderer.beamVisibleDistance(8));
+    }
+
+    @Test
+    void farLabelIsProjectedInsideTheCameraFarPlane() {
+        final double projectionDistance = WaypointWorldRenderer.labelProjectionDistance(8);
+
+        assertEquals(115.2, projectionDistance, 0.0001);
+        assertEquals(
+            projectionDistance,
+            WaypointWorldRenderer.projectedLabelDistance(512.0, projectionDistance)
+        );
+    }
+
+    @Test
+    void nearbyLabelKeepsItsActualPosition() {
+        assertEquals(
+            64.0,
+            WaypointWorldRenderer.projectedLabelDistance(
+                64.0,
+                WaypointWorldRenderer.labelProjectionDistance(8)
+            )
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- separate vanilla-limited waypoint beam rendering from configurable label visibility
- preserve the unlimited label setting and project distant labels inside the camera far plane
- keep displayed and targeting distances based on the waypoint's real position
- document the behavior and add regression coverage for cutoff/projection math

## Testing
- `./gradlew :1.21.11:test --tests cn.net.rms.confluxmap.mc.ui.world.WaypointWorldRendererDistanceTest --tests cn.net.rms.confluxmap.mc.ui.world.WaypointHudProjectionTest -x :common:test --no-daemon`
- `./gradlew :26.2:compileJava --no-daemon`
- manual test client launch on Minecraft 1.21.11

Closes #76

## Summary by Sourcery

Keep distant waypoint labels visible while maintaining independent beam visibility and accurate waypoint distance information.

Bug Fixes:
- Keep distant waypoint labels visible independently of beam rendering and preserve unlimited label visibility settings.
- Retain real waypoint distances for label display and targeting while projecting far labels within the camera far plane.

Enhancements:
- Separate waypoint beam and label distance rules so beams follow vanilla view distance while labels use the configured cutoff.
- Document distant-label rendering behavior and add regression coverage for distance and projection calculations.

Documentation:
- Update the waypoint UX specification to describe configurable label cutoffs, unlimited labels, and far-plane projection.

Tests:
- Add regression tests covering label distance limits, beam distance limits, far-label projection, and nearby label positioning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Waypoint labels now remain visible beyond the camera’s far plane while preserving their apparent size.
  * Configured waypoint distance limits apply to labels, including unlimited mode.
  * Vertical waypoint beams continue to follow the game’s standard view distance.

* **Documentation**
  * Updated the rendering specification to clarify label and beam visibility behavior.

* **Tests**
  * Added coverage for label distance, unlimited visibility, beam limits, and far-plane positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->