### PR TITLE
feat(radar): add configurable portrait outlines

### DIFF
--- a/common/src/main/java/cn/net/rms/confluxmap/core/config/ConfluxConfig.java
+++ b/common/src/main/java/cn/net/rms/confluxmap/core/config/ConfluxConfig.java
@@ -23,6 +23,9 @@ public final class ConfluxConfig {
     public static final int MIN_RADAR_ICON_SIZE = 4;
     public static final int MAX_RADAR_ICON_SIZE = 16;
     public static final int DEFAULT_RADAR_ICON_SIZE = 10;
+    public static final int MIN_RADAR_ICON_OUTLINE_THICKNESS = 0;
+    public static final int MAX_RADAR_ICON_OUTLINE_THICKNESS = 4;
+    public static final int DEFAULT_RADAR_ICON_OUTLINE_THICKNESS = 1;
     public static final int MIN_WAYPOINT_ICON_OPACITY = 0;
     public static final int MAX_WAYPOINT_ICON_OPACITY = 100;
     public static final int DEFAULT_WAYPOINT_ICON_OPACITY = 100;
@@ -134,6 +137,10 @@ public final class ConfluxConfig {
     public int radarMaxEntities = 100;
     /** Entity head and item-form icons instead of plain shaped dots when an in-game icon is available. */
     public boolean radarIconsEnabled = true;
+    /** Draw an outline around radar portraits; retained name keeps older config files compatible. */
+    public boolean radarPlayerIconOutlineEnabled = true;
+    /** Radar portrait outline thickness in screen pixels; zero disables the outline. */
+    public int radarIconOutlineThickness = DEFAULT_RADAR_ICON_OUTLINE_THICKNESS;
     /** Merge overlapping markers of the same visible kind into a single counted marker. */
     public boolean radarMergeEnabled = true;
     /** Screen-pixel size shared by entity faces and item-form radar icons. */
@@ -242,6 +249,8 @@ public final class ConfluxConfig {
         c.radarShowPlayerNames = radarShowPlayerNames;
         c.radarMaxEntities = radarMaxEntities;
         c.radarIconsEnabled = radarIconsEnabled;
+        c.radarPlayerIconOutlineEnabled = radarPlayerIconOutlineEnabled;
+        c.radarIconOutlineThickness = radarIconOutlineThickness;
         c.radarMergeEnabled = radarMergeEnabled;
         c.radarIconSize = radarIconSize;
         c.waypointRenderDistance = waypointRenderDistance;
@@ -337,6 +346,11 @@ public final class ConfluxConfig {
         gpuTileCacheLimit = clamp(gpuTileCacheLimit, 16, 2048);
         radarMaxEntities = clamp(radarMaxEntities, 1, 500);
         radarIconSize = clamp(radarIconSize, MIN_RADAR_ICON_SIZE, MAX_RADAR_ICON_SIZE);
+        radarIconOutlineThickness = clamp(
+            radarIconOutlineThickness,
+            MIN_RADAR_ICON_OUTLINE_THICKNESS,
+            MAX_RADAR_ICON_OUTLINE_THICKNESS
+        );
         waypointRenderDistance = clamp(waypointRenderDistance, 0, 100_000);
         waypointLabelScalePercent = clamp(
             waypointLabelScalePercent,

--- a/common/src/main/java/cn/net/rms/confluxmap/core/radar/PortraitLayout.java
+++ b/common/src/main/java/cn/net/rms/confluxmap/core/radar/PortraitLayout.java
@@ -5,7 +5,6 @@ import java.util.Set;
 
 /** Minecraft-free projection and sizing policy for model-derived radar portraits. */
 public final class PortraitLayout {
-    private static final float TARGET_SUBJECT_AREA_RATIO = 0.5f;
     private static final Set<String> SIDE_VIEW_TYPES = Set.of(
         "minecraft:cod", "minecraft:salmon", "minecraft:pufferfish", "minecraft:tropical_fish"
     );
@@ -35,9 +34,9 @@ public final class PortraitLayout {
     }
 
     /**
-     * Gives the already-selected subject a stable visual area. Callers must pass the dominant
-     * subject dimensions, not the complete silhouette including thin ears, horns, antennae, or
-     * decorative layers. Long subjects may exceed the cell bounds; the atlas bake clips them.
+     * Fits the already-selected subject into the portrait while preserving its aspect ratio.
+     * Callers must pass the dominant subject dimensions, not the complete silhouette including
+     * thin ears, horns, antennae, or decorative layers.
      */
     public static Fit fit(
         final float rawWidth,
@@ -52,8 +51,7 @@ public final class PortraitLayout {
         if (!(content > 0f)) {
             throw new IllegalArgumentException("portrait padding leaves no content area");
         }
-        final float targetArea = content * content * TARGET_SUBJECT_AREA_RATIO;
-        final float scale = (float) Math.sqrt(targetArea / (rawWidth * rawHeight));
+        final float scale = Math.min(content / rawWidth, content / rawHeight);
         final float width = rawWidth * scale;
         final float height = rawHeight * scale;
         return new Fit(scale, width, height, (cellSize - width) / 2f, (cellSize - height) / 2f);

--- a/common/src/test/java/cn/net/rms/confluxmap/core/config/ConfigIoTest.java
+++ b/common/src/test/java/cn/net/rms/confluxmap/core/config/ConfigIoTest.java
@@ -24,6 +24,19 @@ class ConfigIoTest {
     private static final Logger LOGGER = LogManager.getLogger("ConfigIoTest");
 
     @Test
+    void playerIconOutlineChoiceRoundTrips(@TempDir final Path tmp) throws IOException {
+        final ConfigIo io = new ConfigIo(tmp.resolve("config.json"), LOGGER);
+        final ConfluxConfig config = new ConfluxConfig();
+        config.radarPlayerIconOutlineEnabled = false;
+
+        io.save(config);
+
+        assertFalse(io.load().radarPlayerIconOutlineEnabled);
+        assertEquals(ConfluxConfig.DEFAULT_RADAR_ICON_OUTLINE_THICKNESS,
+            new ConfluxConfig().radarIconOutlineThickness);
+    }
+
+    @Test
     void playerMarkerStyleRoundTripsCopiesAndDefaultsSafely(@TempDir final Path tmp)
         throws IOException {
         final Path file = tmp.resolve("config.json");
@@ -101,6 +114,9 @@ class ConfigIoTest {
         assertEquals(MapColorStyle.CONFLUX, loaded.mapColorStyle);
         assertEquals(ConfluxConfig.DEFAULT_RADAR_ICON_SIZE, loaded.radarIconSize);
         assertTrue(loaded.radarMergeEnabled);
+        assertTrue(loaded.radarPlayerIconOutlineEnabled);
+        assertEquals(ConfluxConfig.DEFAULT_RADAR_ICON_OUTLINE_THICKNESS,
+            loaded.radarIconOutlineThickness);
         assertTrue(loaded.playerTrailEnabled);
         assertEquals(
             ConfluxConfig.DEFAULT_PLAYER_TRAIL_DURATION_SECONDS,
@@ -134,6 +150,8 @@ class ConfigIoTest {
         assertTrue(rewritten.contains("\"mapColorStyle\""));
         assertTrue(rewritten.contains("\"radarIconSize\""));
         assertTrue(rewritten.contains("\"radarMergeEnabled\""));
+        assertTrue(rewritten.contains("\"radarPlayerIconOutlineEnabled\""));
+        assertTrue(rewritten.contains("\"radarIconOutlineThickness\""));
         assertTrue(rewritten.contains("\"playerTrailEnabled\""));
         assertTrue(rewritten.contains("\"playerTrailDurationSeconds\""));
         assertFalse(rewritten.contains("\"playerTrailDurationMinutes\""));

--- a/common/src/test/java/cn/net/rms/confluxmap/core/config/ConfluxConfigTest.java
+++ b/common/src/test/java/cn/net/rms/confluxmap/core/config/ConfluxConfigTest.java
@@ -8,6 +8,19 @@ import org.junit.jupiter.api.Test;
 
 final class ConfluxConfigTest {
     @Test
+    void playerIconOutlineIsEnabledByDefaultAndSurvivesConfigCopy() {
+        final ConfluxConfig config = new ConfluxConfig();
+
+        assertTrue(config.radarPlayerIconOutlineEnabled);
+        assertEquals(ConfluxConfig.DEFAULT_RADAR_ICON_OUTLINE_THICKNESS,
+            config.radarIconOutlineThickness);
+        config.radarPlayerIconOutlineEnabled = false;
+        config.radarIconOutlineThickness = 4;
+        assertFalse(config.copy().radarPlayerIconOutlineEnabled);
+        assertEquals(4, config.copy().radarIconOutlineThickness);
+    }
+
+    @Test
     void radarMarkerMergingIsEnabledByDefault() {
         assertTrue(new ConfluxConfig().radarMergeEnabled);
     }

--- a/common/src/test/java/cn/net/rms/confluxmap/core/radar/PortraitLayoutTest.java
+++ b/common/src/test/java/cn/net/rms/confluxmap/core/radar/PortraitLayoutTest.java
@@ -10,31 +10,27 @@ class PortraitLayoutTest {
     private static final float EPSILON = 0.001f;
 
     @Test
-    void givesOrdinarySubjectsTheSameVisualArea() {
+    void fillsTheLongestAxisWithoutChangingAspectRatio() {
         final float cell = 32f;
         final float padding = 1f;
-        final float targetArea = 450f;
 
         for (final float[] raw : new float[][] {
             {10f, 10f}, {9f, 12f}, {15f, 10f}, {40f, 41f}
         }) {
             final PortraitLayout.Fit fit = PortraitLayout.fit(raw[0], raw[1], cell, padding);
 
-            assertEquals(
-                targetArea, fit.width() * fit.height(), EPSILON,
-                () -> "subject " + raw[0] + "x" + raw[1] + " must occupy the same visual area"
-            );
-            assertEquals(raw[0] / raw[1], fit.width() / fit.height(), EPSILON, "aspect ratio must survive");
+            assertEquals(raw[0] / raw[1], fit.width() / fit.height(), EPSILON);
+            assertEquals(30f, Math.max(fit.width(), fit.height()), EPSILON);
         }
     }
 
     @Test
-    void keepsTheVisualAreaWhenAnElongatedSubjectNeedsClipping() {
+    void keepsAnElongatedSubjectWide() {
         final PortraitLayout.Fit fit = PortraitLayout.fit(24f, 6f, 32f, 1f);
 
-        assertEquals(450f, fit.width() * fit.height(), EPSILON);
-        assertTrue(fit.width() > 30f);
-        assertTrue(fit.left() < 0f);
+        assertEquals(30f, fit.width(), EPSILON);
+        assertEquals(7.5f, fit.height(), EPSILON);
+        assertEquals(4f, fit.width() / fit.height(), EPSILON);
     }
 
     @Test
@@ -42,7 +38,7 @@ class PortraitLayoutTest {
         final PortraitLayout.Fit fit = PortraitLayout.fit(10f, 10f, 32f, 1f);
 
         assertEquals(fit.left(), fit.top(), EPSILON);
-        assertTrue(fit.left() > 1f);
+        assertEquals(1f, fit.left(), EPSILON);
     }
 
     @Test

--- a/docs/reference-specs/radar-icons.md
+++ b/docs/reference-specs/radar-icons.md
@@ -156,11 +156,16 @@ coat/marking layers.
 > current entity model into a persistent color atlas. Stable child names select the head group;
 > unfamiliar models fall back through body, cube, segments, and finally the model root. At most
 > one missing portrait is baked per client tick, with the shaped category marker used until it is
-> ready or when a bake cannot be drawn. Dynamic portraits use area-normalized sizing;
+> ready or when a bake cannot be drawn. Dynamic portraits are tightly cropped to their projected
+> geometry, keep the model's aspect ratio, and scale their longest edge to the configured icon
+> size. Their optional outline expands the sampled alpha silhouette rather than framing its
+> rectangular bounds, so long fish stay wide without acquiring a black rectangular box;
 > horse-like long heads use a fixed three-quarter view while fish retain a side view. Bundled,
-> dynamic, player, and item icons all render without a generated surrounding border. Player faces
-> remain direct skin face/hat crops. Dynamic atlas entries are keyed by entity type, resolved
-> texture, and selected model, so entities with the same visual appearance share one bake. Each
+> dynamic and item icons render without a generated surrounding border. Entity faces remain direct
+> model/skin crops and can optionally receive a silhouette-following outline at draw time; the
+> outline applies to all face icons, with configurable enablement and thickness, and updates
+> immediately when toggled. Dynamic atlas entries are keyed by entity type, resolved texture, and
+> selected model, so entities with the same visual appearance share one bake. Each
 > entity's appearance key is rechecked periodically, but an unchanged key is never re-rendered;
 > resource reloads and session changes invalidate the atlas explicitly.
 

--- a/src/main/java/cn/net/rms/confluxmap/mc/radar/EntityHeadGeometry.java
+++ b/src/main/java/cn/net/rms/confluxmap/mc/radar/EntityHeadGeometry.java
@@ -46,16 +46,10 @@ import net.minecraft.util.math.Vector4f;
 /** Extracts textured quads for only the face-like portion of a neutralized vanilla entity model. */
 final class EntityHeadGeometry {
     private static final int CELL_PX = 32;
-    /** Transparent margin that stops a scaled portrait from sampling its atlas neighbour. */
-    private static final int CONTENT_PAD = 1;
+    /** Tight crops provide their own sampling bounds, so the dominant subject may use the cell. */
+    private static final int CONTENT_PAD = 0;
     /** Keeps equally dominant cuboids together for multi-part subjects such as wither heads. */
     private static final float DOMINANT_SCORE_RATIO = 0.99f;
-    /** Target raster area for the complete silhouette after the compact subject establishes scale. */
-    private static final float TARGET_OCCUPIED_AREA_RATIO = 0.54f;
-    /** Minimum share of the total-area target reserved for the compact subject itself. */
-    private static final float MIN_SUBJECT_OCCUPIED_RATIO = 0.8f;
-    /** Keeps a readable compact face even when its angled raster footprint looks deceptively full. */
-    private static final float MIN_SUBJECT_VISUAL_AREA_RATIO = 0.81f;
     //#if MC<12103
     private static final String MAIN_LAYER = "main";
     private static final Map<String, ModelPart> DATA_ROOTS = new LinkedHashMap<>();
@@ -214,7 +208,6 @@ final class EntityHeadGeometry {
         float subjectMinY = Float.POSITIVE_INFINITY;
         float subjectMaxX = Float.NEGATIVE_INFINITY;
         float subjectMaxY = Float.NEGATIVE_INFINITY;
-        final List<RawCuboid> subjectCuboids = new ArrayList<>();
         for (final RawCuboid cuboid : cuboids) {
             final float dominance = planarSubject
                 ? cuboid.bounds().projectedDominance()
@@ -222,7 +215,6 @@ final class EntityHeadGeometry {
             if (dominance < largestDominance * DOMINANT_SCORE_RATIO) {
                 continue;
             }
-            subjectCuboids.add(cuboid);
             subjectMinX = Math.min(subjectMinX, cuboid.bounds().minX());
             subjectMinY = Math.min(subjectMinY, cuboid.bounds().minY());
             subjectMaxX = Math.max(subjectMaxX, cuboid.bounds().maxX());
@@ -236,174 +228,22 @@ final class EntityHeadGeometry {
         final List<RawQuad> quads = cuboids.stream().flatMap(cuboid -> cuboid.quads().stream())
             .sorted(Comparator.comparingDouble(RawQuad::depth).reversed())
             .toList();
-        final List<RawQuad> subjectQuads = subjectCuboids.stream()
-            .flatMap(cuboid -> cuboid.quads().stream())
-            .toList();
         final PortraitLayout.Fit fit = PortraitLayout.fit(width, height, CELL_PX, CONTENT_PAD);
-        final float baselineScale = fit.scale();
-        final int occupiedPixels = occupiedPixels(
-            quads, subjectMinX, subjectMinY, width, height, baselineScale
-        );
-        final float targetOccupiedPixels = (CELL_PX - 2f * CONTENT_PAD)
-            * (CELL_PX - 2f * CONTENT_PAD) * TARGET_OCCUPIED_AREA_RATIO;
-        final float coverageScale = occupiedPixels > 0
-            ? baselineScale * (float) Math.sqrt(targetOccupiedPixels / occupiedPixels)
-            : baselineScale;
-        final int subjectOccupiedPixels = occupiedPixels(
-            subjectQuads, subjectMinX, subjectMinY, width, height, baselineScale
-        );
-        final float minimumSubjectPixels = targetOccupiedPixels * MIN_SUBJECT_OCCUPIED_RATIO;
-        final float subjectVisualArea = largestCompactQuadArea(subjectQuads, baselineScale);
-        final float minimumSubjectVisualArea = fit.width() * fit.height()
-            * MIN_SUBJECT_VISUAL_AREA_RATIO;
-        // Whole-model portraits have no smaller face to protect. For head portraits, solve a
-        // second scale from the compact cuboids alone so ears, antlers and tendrils can influence
-        // the total without shrinking the recognizable subject below its own pixel floor.
-        final float minimumSubjectPixelScale = HeadPartSelector.usesFullModel(entityType)
-            || subjectOccupiedPixels <= 0
-            ? 0f
-            : baselineScale * (float) Math.sqrt(minimumSubjectPixels / subjectOccupiedPixels);
-        final float minimumSubjectVisualScale = HeadPartSelector.usesFullModel(entityType)
-            || !(subjectVisualArea > 0f)
-            ? 0f
-            : baselineScale * (float) Math.sqrt(minimumSubjectVisualArea / subjectVisualArea);
-        final float scale = Math.max(
-            coverageScale, Math.max(minimumSubjectPixelScale, minimumSubjectVisualScale)
-        );
-        final float offsetX = cellX + (CELL_PX - width * scale) / 2f;
-        final float offsetY = cellY + (CELL_PX - height * scale) / 2f;
+        final float offsetX = cellX + fit.left();
+        final float offsetY = cellY + fit.top();
 
         final float[] projected = new float[quads.size() * 20];
         int out = 0;
         for (final RawQuad quad : quads) {
             for (final RawVertex vertex : quad.vertices()) {
-                projected[out++] = offsetX + (vertex.x() - subjectMinX) * scale;
-                projected[out++] = offsetY + (vertex.y() - subjectMinY) * scale;
+                projected[out++] = offsetX + (vertex.x() - subjectMinX) * fit.scale();
+                projected[out++] = offsetY + (vertex.y() - subjectMinY) * fit.scale();
                 projected[out++] = 0f;
                 projected[out++] = vertex.u();
                 projected[out++] = vertex.v();
             }
         }
         return projected;
-    }
-
-    private static float largestCompactQuadArea(final List<RawQuad> quads, final float scale) {
-        float bestCompactness = 0f;
-        float bestArea = 0f;
-        for (final RawQuad quad : quads) {
-            float minX = Float.POSITIVE_INFINITY;
-            float minY = Float.POSITIVE_INFINITY;
-            float maxX = Float.NEGATIVE_INFINITY;
-            float maxY = Float.NEGATIVE_INFINITY;
-            for (final RawVertex vertex : quad.vertices()) {
-                minX = Math.min(minX, vertex.x());
-                minY = Math.min(minY, vertex.y());
-                maxX = Math.max(maxX, vertex.x());
-                maxY = Math.max(maxY, vertex.y());
-            }
-            final float width = (maxX - minX) * scale;
-            final float height = (maxY - minY) * scale;
-            final float compactness = Math.min(width, height) * Math.min(width, height);
-            if (compactness > bestCompactness) {
-                bestCompactness = compactness;
-                bestArea = width * height;
-            }
-        }
-        return bestArea;
-    }
-
-    private static int occupiedPixels(
-        final List<RawQuad> quads,
-        final float subjectMinX,
-        final float subjectMinY,
-        final float subjectWidth,
-        final float subjectHeight,
-        final float scale
-    ) {
-        final float offsetX = (CELL_PX - subjectWidth * scale) / 2f;
-        final float offsetY = (CELL_PX - subjectHeight * scale) / 2f;
-        final boolean[][] occupied = new boolean[CELL_PX][CELL_PX];
-        for (final RawQuad quad : quads) {
-            final float[] xs = new float[4];
-            final float[] ys = new float[4];
-            float minX = Float.POSITIVE_INFINITY;
-            float minY = Float.POSITIVE_INFINITY;
-            float maxX = Float.NEGATIVE_INFINITY;
-            float maxY = Float.NEGATIVE_INFINITY;
-            for (int i = 0; i < 4; i++) {
-                final RawVertex vertex = quad.vertices().get(i);
-                xs[i] = offsetX + (vertex.x() - subjectMinX) * scale;
-                ys[i] = offsetY + (vertex.y() - subjectMinY) * scale;
-                minX = Math.min(minX, xs[i]);
-                minY = Math.min(minY, ys[i]);
-                maxX = Math.max(maxX, xs[i]);
-                maxY = Math.max(maxY, ys[i]);
-            }
-            final int firstX = Math.max(CONTENT_PAD, (int) Math.floor(minX));
-            final int firstY = Math.max(CONTENT_PAD, (int) Math.floor(minY));
-            final int lastX = Math.min(CELL_PX - CONTENT_PAD, (int) Math.ceil(maxX));
-            final int lastY = Math.min(CELL_PX - CONTENT_PAD, (int) Math.ceil(maxY));
-            for (int y = firstY; y < lastY; y++) {
-                for (int x = firstX; x < lastX; x++) {
-                    if (occupied[y][x]) {
-                        continue;
-                    }
-                    final float px = x + 0.5f;
-                    final float py = y + 0.5f;
-                    if (insideTriangle(xs, ys, 0, 1, 2, px, py)
-                        || insideTriangle(xs, ys, 0, 2, 3, px, py)) {
-                        occupied[y][x] = true;
-                    }
-                }
-            }
-        }
-        int count = 0;
-        for (final boolean[] row : occupied) {
-            for (final boolean pixel : row) {
-                if (pixel) {
-                    count++;
-                }
-            }
-        }
-        return count;
-    }
-
-    private static boolean insideTriangle(
-        final float[] xs,
-        final float[] ys,
-        final int first,
-        final int second,
-        final int third,
-        final float px,
-        final float py
-    ) {
-        final float ax = xs[first];
-        final float ay = ys[first];
-        final float bx = xs[second];
-        final float by = ys[second];
-        final float cx = xs[third];
-        final float cy = ys[third];
-        final float triangleArea = sign(ax, ay, bx, by, cx, cy);
-        if (Math.abs(triangleArea) < 0.0001f) {
-            return false;
-        }
-        final float firstSign = sign(ax, ay, bx, by, px, py);
-        final float secondSign = sign(bx, by, cx, cy, px, py);
-        final float thirdSign = sign(cx, cy, ax, ay, px, py);
-        final boolean hasNegative = firstSign < 0f || secondSign < 0f || thirdSign < 0f;
-        final boolean hasPositive = firstSign > 0f || secondSign > 0f || thirdSign > 0f;
-        return !(hasNegative && hasPositive);
-    }
-
-    private static float sign(
-        final float ax,
-        final float ay,
-        final float bx,
-        final float by,
-        final float px,
-        final float py
-    ) {
-        return (px - bx) * (ay - by) - (ax - bx) * (py - by);
     }
 
     /**

--- a/src/main/java/cn/net/rms/confluxmap/mc/radar/EntityIconManager.java
+++ b/src/main/java/cn/net/rms/confluxmap/mc/radar/EntityIconManager.java
@@ -1,22 +1,30 @@
 package cn.net.rms.confluxmap.mc.radar;
 
 import cn.net.rms.confluxmap.ConfluxMapMod;
+import cn.net.rms.confluxmap.compat.MinecraftAccess;
+import cn.net.rms.confluxmap.compat.NativeImages;
 import cn.net.rms.confluxmap.compat.Regs;
 import cn.net.rms.confluxmap.core.radar.IconBakeCache;
+import cn.net.rms.confluxmap.core.util.Argb;
 import cn.net.rms.confluxmap.mixin.AgeableMobEntityRendererAccessor;
 import cn.net.rms.confluxmap.mc.render.OffscreenCanvas;
 import cn.net.rms.confluxmap.mc.render.RenderUtil;
 import com.mojang.blaze3d.systems.RenderSystem;
+import java.io.IOException;
+import java.io.InputStream;
 import java.lang.ref.WeakReference;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.function.IntBinaryOperator;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.AbstractClientPlayerEntity;
 import net.minecraft.client.render.entity.EntityRenderer;
 import net.minecraft.client.render.entity.LivingEntityRenderer;
 import net.minecraft.client.render.entity.model.EntityModel;
+import net.minecraft.client.texture.NativeImage;
 //#if MC>=12103
 //$$ import net.minecraft.client.render.entity.state.LivingEntityRenderState;
 //#endif
@@ -31,7 +39,15 @@ import net.minecraft.util.Identifier;
  * Callers see one small lookup interface and never handle model or version-specific renderer APIs.
  */
 public final class EntityIconManager implements AutoCloseable {
-    private record AtlasSprite(int slot, float u0, float v0, float u1, float v1) {
+    private record AtlasSprite(
+        int slot,
+        float u0,
+        float v0,
+        float u1,
+        float v1,
+        float widthScale,
+        float heightScale
+    ) {
     }
 
     private record PortraitKey(Identifier entityType, Identifier texture, EntityModel<?> model) {
@@ -44,7 +60,7 @@ public final class EntityIconManager implements AutoCloseable {
     public record FaceIcon(
         Identifier texture, float u0, float v0, float u1, float v1,
         Identifier overlayTexture, float ou0, float ov0, float ou1, float ov1,
-        boolean dynamic
+        boolean dynamic, float widthScale, float heightScale
     ) {
         public boolean hasOverlay() {
             return overlayTexture != null;
@@ -75,6 +91,8 @@ public final class EntityIconManager implements AutoCloseable {
     );
     private final Map<PortraitKey, WeakReference<LivingEntity>> liveEntities = new HashMap<>();
     private final Map<UUID, ObservedPortrait> observedPortraits = new HashMap<>();
+    private final Map<Identifier, NativeImage> sourceTextures = new HashMap<>();
+    private final Set<Identifier> unreadableSourceTextures = new java.util.HashSet<>();
 
     private int nextSlot;
     private long clock;
@@ -233,6 +251,9 @@ public final class EntityIconManager implements AutoCloseable {
         }
         final int column = sprite.slot() % CELLS_PER_ROW;
         final int row = sprite.slot() / CELLS_PER_ROW;
+        final AtlasSprite cropped = cropSprite(
+            sprite, geometry, sourceTexture(client, key.texture())
+        );
         translate(geometry, column * CELL_PX, row * CELL_PX);
 
         final MatrixStack matrices = new MatrixStack();
@@ -252,7 +273,7 @@ public final class EntityIconManager implements AutoCloseable {
         } finally {
             colorAtlas.end(client);
         }
-        return sprite;
+        return cropped;
     }
 
     //#if MC>=12103
@@ -296,7 +317,181 @@ public final class EntityIconManager implements AutoCloseable {
         // (V=1). Flip the complete atlas row, not only the orientation inside that row.
         final float v0 = atlasTopV(row);
         final float v1 = atlasBottomV(row);
-        return new AtlasSprite(slot, u0, v0, u1, v1);
+        return new AtlasSprite(slot, u0, v0, u1, v1, 1f, 1f);
+    }
+
+    private NativeImage sourceTexture(final MinecraftClient client, final Identifier texture) {
+        final NativeImage cached = sourceTextures.get(texture);
+        if (cached != null || unreadableSourceTextures.contains(texture)) {
+            return cached;
+        }
+        try (InputStream input = MinecraftAccess.openResource(client, texture)) {
+            final NativeImage image = NativeImage.read(input);
+            sourceTextures.put(texture, image);
+            return image;
+        } catch (final IOException | RuntimeException e) {
+            unreadableSourceTextures.add(texture);
+            ConfluxMapMod.LOGGER.debug("Could not inspect radar portrait alpha for {}", texture, e);
+            return null;
+        }
+    }
+
+    /** Tightens atlas sampling and records the aspect-preserving destination rectangle. */
+    private static AtlasSprite cropSprite(
+        final AtlasSprite sprite,
+        final float[] geometry,
+        final NativeImage sourceTexture
+    ) {
+        final int[] visible = sourceTexture == null
+            ? null
+            : visibleBounds(
+                geometry, sourceTexture.getWidth(), sourceTexture.getHeight(),
+                (x, y) -> Argb.alpha(NativeImages.getArgb(sourceTexture, x, y))
+            );
+        final int[] bounds = visible == null ? geometryBounds(geometry) : visible;
+        final int left = bounds[0];
+        final int top = bounds[1];
+        final int right = bounds[2];
+        final int bottom = bounds[3];
+        final int width = right - left;
+        final int height = bottom - top;
+        final int column = sprite.slot() % CELLS_PER_ROW;
+        final int row = sprite.slot() / CELLS_PER_ROW;
+        final float longest = Math.max(width, height);
+        return new AtlasSprite(
+            sprite.slot(),
+            (column * CELL_PX + left) / (float) ATLAS_PX,
+            1f - (row * CELL_PX + top) / (float) ATLAS_PX,
+            (column * CELL_PX + right) / (float) ATLAS_PX,
+            1f - (row * CELL_PX + bottom) / (float) ATLAS_PX,
+            width / longest,
+            height / longest
+        );
+    }
+
+    private static int[] geometryBounds(final float[] geometry) {
+        float minX = Float.POSITIVE_INFINITY;
+        float minY = Float.POSITIVE_INFINITY;
+        float maxX = Float.NEGATIVE_INFINITY;
+        float maxY = Float.NEGATIVE_INFINITY;
+        for (int i = 0; i < geometry.length; i += 5) {
+            minX = Math.min(minX, geometry[i]);
+            minY = Math.min(minY, geometry[i + 1]);
+            maxX = Math.max(maxX, geometry[i]);
+            maxY = Math.max(maxY, geometry[i + 1]);
+        }
+        return normalizedBounds(minX, minY, maxX, maxY);
+    }
+
+    static int[] visibleBounds(
+        final float[] geometry,
+        final int textureWidth,
+        final int textureHeight,
+        final IntBinaryOperator alphaAt
+    ) {
+        boolean found = false;
+        int left = CELL_PX;
+        int top = CELL_PX;
+        int right = 0;
+        int bottom = 0;
+        for (int quad = 0; quad < geometry.length; quad += 20) {
+            for (final int[] triangle : new int[][] {{0, 1, 2}, {0, 2, 3}}) {
+                final float minX = Math.min(
+                    geometry[quad + triangle[0] * 5],
+                    Math.min(geometry[quad + triangle[1] * 5], geometry[quad + triangle[2] * 5])
+                );
+                final float minY = Math.min(
+                    geometry[quad + triangle[0] * 5 + 1],
+                    Math.min(geometry[quad + triangle[1] * 5 + 1], geometry[quad + triangle[2] * 5 + 1])
+                );
+                final float maxX = Math.max(
+                    geometry[quad + triangle[0] * 5],
+                    Math.max(geometry[quad + triangle[1] * 5], geometry[quad + triangle[2] * 5])
+                );
+                final float maxY = Math.max(
+                    geometry[quad + triangle[0] * 5 + 1],
+                    Math.max(geometry[quad + triangle[1] * 5 + 1], geometry[quad + triangle[2] * 5 + 1])
+                );
+                final int firstX = clamp((int) Math.floor(minX), 0, CELL_PX - 1);
+                final int firstY = clamp((int) Math.floor(minY), 0, CELL_PX - 1);
+                final int lastX = clamp((int) Math.ceil(maxX), 1, CELL_PX);
+                final int lastY = clamp((int) Math.ceil(maxY), 1, CELL_PX);
+                for (int y = firstY; y < lastY; y++) {
+                    for (int x = firstX; x < lastX; x++) {
+                        final float[] weights = barycentric(
+                            geometry, quad, triangle, x + 0.5f, y + 0.5f
+                        );
+                        if (weights == null) {
+                            continue;
+                        }
+                        float u = 0f;
+                        float v = 0f;
+                        for (int i = 0; i < 3; i++) {
+                            final int vertex = quad + triangle[i] * 5;
+                            u += geometry[vertex + 3] * weights[i];
+                            v += geometry[vertex + 4] * weights[i];
+                        }
+                        final int textureX = clamp((int) (u * textureWidth), 0, textureWidth - 1);
+                        final int textureY = clamp((int) (v * textureHeight), 0, textureHeight - 1);
+                        if (alphaAt.applyAsInt(textureX, textureY) <= 8) {
+                            continue;
+                        }
+                        found = true;
+                        left = Math.min(left, x);
+                        top = Math.min(top, y);
+                        right = Math.max(right, x + 1);
+                        bottom = Math.max(bottom, y + 1);
+                    }
+                }
+            }
+        }
+        return found ? new int[] {left, top, right, bottom} : null;
+    }
+
+    private static float[] barycentric(
+        final float[] geometry,
+        final int quad,
+        final int[] triangle,
+        final float px,
+        final float py
+    ) {
+        final int a = quad + triangle[0] * 5;
+        final int b = quad + triangle[1] * 5;
+        final int c = quad + triangle[2] * 5;
+        final float denominator = (geometry[b + 1] - geometry[c + 1])
+            * (geometry[a] - geometry[c])
+            + (geometry[c] - geometry[b]) * (geometry[a + 1] - geometry[c + 1]);
+        if (Math.abs(denominator) < 0.0001f) {
+            return null;
+        }
+        final float wa = ((geometry[b + 1] - geometry[c + 1]) * (px - geometry[c])
+            + (geometry[c] - geometry[b]) * (py - geometry[c + 1])) / denominator;
+        final float wb = ((geometry[c + 1] - geometry[a + 1]) * (px - geometry[c])
+            + (geometry[a] - geometry[c]) * (py - geometry[c + 1])) / denominator;
+        final float wc = 1f - wa - wb;
+        return wa >= -0.0001f && wb >= -0.0001f && wc >= -0.0001f
+            ? new float[] {wa, wb, wc}
+            : null;
+    }
+
+    private static int[] normalizedBounds(
+        final float minX,
+        final float minY,
+        final float maxX,
+        final float maxY
+    ) {
+        final int left = clamp((int) Math.floor(minX), 0, CELL_PX - 1);
+        final int top = clamp((int) Math.floor(minY), 0, CELL_PX - 1);
+        return new int[] {
+            left,
+            top,
+            clamp((int) Math.ceil(maxX), left + 1, CELL_PX),
+            clamp((int) Math.ceil(maxY), top + 1, CELL_PX)
+        };
+    }
+
+    private static int clamp(final int value, final int min, final int max) {
+        return Math.max(min, Math.min(max, value));
     }
 
     static float atlasTopV(final int row) {
@@ -312,13 +507,18 @@ public final class EntityIconManager implements AutoCloseable {
         liveEntities.clear();
         observedPortraits.clear();
         colorAtlas.close();
+        for (final NativeImage image : sourceTextures.values()) {
+            image.close();
+        }
+        sourceTextures.clear();
+        unreadableSourceTextures.clear();
         nextSlot = 0;
     }
 
     private static FaceIcon dynamicIcon(final AtlasSprite sprite) {
         return new FaceIcon(
             null, sprite.u0(), sprite.v0(), sprite.u1(), sprite.v1(),
-            null, 0f, 0f, 0f, 0f, true
+            null, 0f, 0f, 0f, 0f, true, sprite.widthScale(), sprite.heightScale()
         );
     }
 
@@ -333,7 +533,7 @@ public final class EntityIconManager implements AutoCloseable {
         return new FaceIcon(
             skin, PLAYER_U0, PLAYER_V0, PLAYER_U1, PLAYER_V1,
             skin, HAT_U0, HAT_V0, HAT_U1, HAT_V1,
-            false
+            false, 1f, 1f
         );
     }
 }

--- a/src/main/java/cn/net/rms/confluxmap/mc/radar/RadarMarkerRenderer.java
+++ b/src/main/java/cn/net/rms/confluxmap/mc/radar/RadarMarkerRenderer.java
@@ -26,7 +26,8 @@ import net.minecraft.item.ItemStack;
  * {@code FullscreenMapScreen} so both surfaces render radar entries identically. Its visual rules
  * evolved from {@code MinimapHudRenderer}'s original radar-marker drawing - see
  * docs/reference-specs/radar-icons.md secs 2-3 for the VoxelMap-style look this reproduces. All
- * portrait and item icons intentionally render without a generated border.
+ * item icons intentionally render without a generated border; entity portraits have an
+ * independently configurable outline.
  */
 public final class RadarMarkerRenderer {
     private static final int PLAYER_COLOR = 0xFFFFFFFF;
@@ -37,6 +38,7 @@ public final class RadarMarkerRenderer {
 
     private static final int STACK_BADGE_BACKGROUND = 0xD0000000;
     private static final int STACK_BADGE_TEXT = 0xFFFFFFFF;
+    private static final int ICON_OUTLINE = 0xD0000000;
     /** No elevation treatment inside this band - nearby mobs always render fully readable. */
     private static final int DEADZONE = 8;
     private static final int TEXT_COLOR = 0xFFFFFFFF;
@@ -54,6 +56,9 @@ public final class RadarMarkerRenderer {
         int yDelta,
         Entity live
     ) {
+    }
+
+    private record DrawResult(float halfWidth, float halfHeight) {
     }
 
     /**
@@ -104,13 +109,13 @@ public final class RadarMarkerRenderer {
             final Marker positioned = new Marker(
                 marker.entry(), cluster.x(), cluster.y(), marker.yDelta(), marker.live()
             );
-            final boolean iconDrawn = drawMarker(
+            final DrawResult result = drawMarker(
                 draw, client, config, iconManager, positioned
             );
             if (cluster.count() > 1) {
                 drawStackCount(
                     draw, client, positioned.x(), positioned.y(),
-                    iconDrawn ? config.radarIconSize / 2f : 2.5f,
+                    result.halfWidth(), result.halfHeight(),
                     config.radarIconSize, cluster.count(), positioned.entry().spectator()
                 );
             }
@@ -126,7 +131,7 @@ public final class RadarMarkerRenderer {
         );
     }
 
-    private static boolean drawMarker(
+    private static DrawResult drawMarker(
         final GuiDraw draw,
         final MinecraftClient client,
         final ConfluxConfig config,
@@ -146,19 +151,24 @@ public final class RadarMarkerRenderer {
                 : ItemStack.EMPTY;
             if (!itemIcon.isEmpty()) {
                 draw.drawItemIcon(client, itemIcon, x, y, config.radarIconSize);
-                return true;
+                return new DrawResult(config.radarIconSize / 2f, config.radarIconSize / 2f);
             }
             final EntityIconManager.FaceIcon icon = iconManager.iconFor(live);
             if (icon != null && drawIcon(
-                    matrices, client, iconManager, icon, x, y, config.radarIconSize,
-                    yDelta, alphaScale
+                matrices, client, iconManager, icon, x, y, config.radarIconSize,
+                yDelta, alphaScale,
+                config.radarPlayerIconOutlineEnabled ? config.radarIconOutlineThickness : 0
                 )) {
                 if (config.radarShowPlayerNames && entry.category() == RadarCategory.PLAYER && entry.name() != null) {
                     drawCenteredLine(
-                        client, draw, entry.name(), x, y + config.radarIconSize / 2f + 2f, alphaScale
+                        client, draw, entry.name(), x,
+                        y + config.radarIconSize * icon.heightScale() / 2f + 2f, alphaScale
                     );
                 }
-                return true;
+                return new DrawResult(
+                    config.radarIconSize * icon.widthScale() / 2f,
+                    config.radarIconSize * icon.heightScale() / 2f
+                );
             }
         }
         final int color = Argb.scaleAlpha(elevationColor(baseColor(entry.category()), yDelta), alphaScale);
@@ -179,7 +189,7 @@ public final class RadarMarkerRenderer {
                 RenderUtil.fillRect(matrices, x - 1.5f, y - 1.5f, 3f, 3f, color);
                 break;
         }
-        return false;
+        return new DrawResult(2.5f, 2.5f);
     }
 
     private static ItemStack itemIconFor(final Entity entity) {
@@ -219,7 +229,7 @@ public final class RadarMarkerRenderer {
     }
 
     /**
-     * Draws the unframed portrait with the same elevation and spectator alpha as dot markers.
+     * Draws the portrait with the same elevation and spectator alpha as dot markers.
      *
      * @return false when the portrait could not be bound, so the caller still draws its dot
      */
@@ -232,9 +242,13 @@ public final class RadarMarkerRenderer {
         final float y,
         final float iconSize,
         final int yDelta,
-        final float alphaScale
+        final float alphaScale,
+        final int outlineThickness
     ) {
-        final float iconHalfSize = iconSize / 2f;
+        final float iconWidth = iconSize * icon.widthScale();
+        final float iconHeight = iconSize * icon.heightScale();
+        final float iconHalfWidth = iconWidth / 2f;
+        final float iconHalfHeight = iconHeight / 2f;
         final int tint = Argb.scaleAlpha(elevationColor(0xFFFFFFFF, yDelta), alphaScale);
         if (icon.dynamic()) {
             if (!iconManager.bindDynamicColor()) {
@@ -243,18 +257,45 @@ public final class RadarMarkerRenderer {
         } else {
             RenderUtil.bindTexture(client, icon.texture());
         }
+        if (outlineThickness > 0) {
+            drawIconOutline(
+                matrices, icon, x, y, iconWidth, iconHeight,
+                outlineThickness, yDelta, alphaScale
+            );
+        }
         RenderUtil.drawTintedQuad(
-            matrices, x - iconHalfSize, y - iconHalfSize, iconSize, iconSize,
+            matrices, x - iconHalfWidth, y - iconHalfHeight, iconWidth, iconHeight,
             icon.u0(), icon.v0(), icon.u1(), icon.v1(), tint
         );
         if (icon.hasOverlay()) {
             RenderUtil.bindTexture(client, icon.overlayTexture());
             RenderUtil.drawTintedQuad(
-                matrices, x - iconHalfSize, y - iconHalfSize, iconSize, iconSize,
+                matrices, x - iconHalfWidth, y - iconHalfHeight, iconWidth, iconHeight,
                 icon.ou0(), icon.ov0(), icon.ou1(), icon.ov1(), tint
             );
         }
         return true;
+    }
+
+    private static void drawIconOutline(
+        final MatrixStack matrices,
+        final EntityIconManager.FaceIcon icon,
+        final float x,
+        final float y,
+        final float iconWidth,
+        final float iconHeight,
+        final int thickness,
+        final int yDelta,
+        final float alphaScale
+    ) {
+        final int color = Argb.scaleAlpha(
+            elevationColor(ICON_OUTLINE, yDelta), alphaScale
+        );
+        RenderUtil.drawTintedOutline(
+            matrices, x - iconWidth / 2f, y - iconHeight / 2f,
+            iconWidth, iconHeight,
+            icon.u0(), icon.v0(), icon.u1(), icon.v1(), thickness, color
+        );
     }
 
     /** Draws a compact count plate centered on the representative marker's bottom-right corner. */
@@ -263,7 +304,8 @@ public final class RadarMarkerRenderer {
         final MinecraftClient client,
         final float x,
         final float y,
-        final float markerHalfSize,
+        final float markerHalfWidth,
+        final float markerHalfHeight,
         final float iconSize,
         final int count,
         final boolean spectator
@@ -274,8 +316,8 @@ public final class RadarMarkerRenderer {
         final int textWidth = client.textRenderer.getWidth(text);
         final float badgeWidth = textWidth * textScale + 2f;
         final float badgeHeight = client.textRenderer.fontHeight * textScale + 1f;
-        final float centerX = x + markerHalfSize - 0.5f;
-        final float centerY = y + markerHalfSize - 0.5f;
+        final float centerX = x + markerHalfWidth - 0.5f;
+        final float centerY = y + markerHalfHeight - 0.5f;
         final float left = centerX - badgeWidth / 2f;
         final float top = centerY - badgeHeight / 2f;
         RenderUtil.fillRect(

--- a/src/main/java/cn/net/rms/confluxmap/mc/render/RenderUtil.java
+++ b/src/main/java/cn/net/rms/confluxmap/mc/render/RenderUtil.java
@@ -365,6 +365,58 @@ public final class RenderUtil {
         //#endif
     }
 
+    /**
+     * Draws a texture-alpha silhouette expanded by {@code radius} GUI pixels. All shifted copies
+     * share one mesh submission; drawing the original texture afterward covers the dark interior,
+     * leaving only the contour around non-transparent pixels.
+     */
+    public static void drawTintedOutline(
+        final MatrixStack matrices,
+        final float x,
+        final float y,
+        final float width,
+        final float height,
+        final float u0,
+        final float v0,
+        final float u1,
+        final float v1,
+        final int radius,
+        final int argbColor
+    ) {
+        if (radius <= 0) {
+            return;
+        }
+        //#if MC<12105
+        useTintedTextureShader();
+        RenderSystem.enableBlend();
+        RenderSystem.defaultBlendFunc();
+        //#endif
+        final float a = Argb.alpha(argbColor) / 255f;
+        final float r = Argb.red(argbColor) / 255f;
+        final float g = Argb.green(argbColor) / 255f;
+        final float b = Argb.blue(argbColor) / 255f;
+        final var model = matrices.peek().getModel();
+        final Mesh mesh = Mesh.beginGui(Mesh.Mode.QUADS, Mesh.tintedTextureFormat());
+        for (int offsetY = -radius; offsetY <= radius; offsetY++) {
+            for (int offsetX = -radius; offsetX <= radius; offsetX++) {
+                if (offsetX == 0 && offsetY == 0) {
+                    continue;
+                }
+                final float left = x + offsetX;
+                final float top = y + offsetY;
+                mesh.tintedVertex(model, left, top + height, 0, u0, v1, r, g, b, a);
+                mesh.tintedVertex(model, left + width, top + height, 0, u1, v1, r, g, b, a);
+                mesh.tintedVertex(model, left + width, top, 0, u1, v0, r, g, b, a);
+                mesh.tintedVertex(model, left, top, 0, u0, v0, r, g, b, a);
+            }
+        }
+        //#if MC>=12105
+        //$$ mesh.drawGui(RenderPipelines.GUI_TEXTURED);
+        //#else
+        mesh.draw();
+        //#endif
+    }
+
     /** Maps one horizontal texture strip clockwise around a circular frame. */
     public static void drawTexturedRing(
         final MatrixStack matrices,

--- a/src/main/java/cn/net/rms/confluxmap/mc/ui/screen/ConfigScreen.java
+++ b/src/main/java/cn/net/rms/confluxmap/mc/ui/screen/ConfigScreen.java
@@ -553,6 +553,20 @@ public final class ConfigScreen extends ConfluxScreen {
                     radarControlsActive, radarTooltipKey
                 );
                 y = addToggleRow(
+                    y, "confluxmap.config.radar.player_icon_outline",
+                    () -> config.radarPlayerIconOutlineEnabled,
+                    v -> config.radarPlayerIconOutlineEnabled = v,
+                    radarControlsActive, radarTooltipKey
+                );
+                y = addIntSliderRow(
+                    y, "confluxmap.config.radar.icon_outline_thickness",
+                    ConfluxConfig.MIN_RADAR_ICON_OUTLINE_THICKNESS,
+                    ConfluxConfig.MAX_RADAR_ICON_OUTLINE_THICKNESS,
+                    () -> config.radarIconOutlineThickness,
+                    v -> config.radarIconOutlineThickness = v,
+                    ConfigScreen::pxText, radarControlsActive, radarTooltipKey
+                );
+                y = addToggleRow(
                     y, "confluxmap.config.radar.merge_enabled",
                     () -> config.radarMergeEnabled, v -> config.radarMergeEnabled = v,
                     radarControlsActive, radarTooltipKey

--- a/src/main/resources/assets/confluxmap/lang/en_us.json
+++ b/src/main/resources/assets/confluxmap/lang/en_us.json
@@ -287,6 +287,8 @@
   "confluxmap.config.radar.show_player_names": "Show Player Names: %s",
   "confluxmap.config.radar.max_entities": "Radar Target Limit: %s",
   "confluxmap.config.radar.icons_enabled": "Entity and Item Icons: %s",
+  "confluxmap.config.radar.player_icon_outline": "Radar Icon Outline: %s",
+  "confluxmap.config.radar.icon_outline_thickness": "Outline Thickness: %s",
   "confluxmap.config.radar.merge_enabled": "Merge Matching Markers: %s",
   "confluxmap.config.radar.icon_size": "Radar Icon Size: %s",
   "confluxmap.screen.config.radar.disabled_by_server": "Entity radar is disabled by this server",

--- a/src/main/resources/assets/confluxmap/lang/zh_cn.json
+++ b/src/main/resources/assets/confluxmap/lang/zh_cn.json
@@ -287,6 +287,8 @@
   "confluxmap.config.radar.show_player_names": "显示玩家名称：%s",
   "confluxmap.config.radar.max_entities": "雷达目标数量上限：%s",
   "confluxmap.config.radar.icons_enabled": "实体与物品图标：%s",
+  "confluxmap.config.radar.player_icon_outline": "雷达图标描边：%s",
+  "confluxmap.config.radar.icon_outline_thickness": "描边粗细：%s",
   "confluxmap.config.radar.merge_enabled": "合并同类标记：%s",
   "confluxmap.config.radar.icon_size": "雷达图标大小：%s",
   "confluxmap.screen.config.radar.disabled_by_server": "此服务器已禁用实体雷达",

--- a/src/test/java/cn/net/rms/confluxmap/mc/radar/EntityHeadGeometryTest.java
+++ b/src/test/java/cn/net/rms/confluxmap/mc/radar/EntityHeadGeometryTest.java
@@ -81,7 +81,7 @@ final class EntityHeadGeometryTest {
     }
 
     @Test
-    void rabbitSubjectIsComparableToPig() {
+    void rabbitPortraitKeepsCompleteModelGeometry() {
         //#if MC>=260100
         //$$ final ModelPart rabbitRoot = AdultRabbitModel.createBodyLayer().bakeRoot();
         //#elseif MC>=12103
@@ -94,9 +94,11 @@ final class EntityHeadGeometryTest {
             "minecraft:rabbit", 0, 0
         );
 
-        final float pigSubjectArea = subjectQuadArea(projectPig());
-        final float rabbitSubjectArea = subjectQuadArea(rabbit);
-        assertComparableToPig("rabbit", rabbitSubjectArea, pigSubjectArea);
+        assertTrue(rabbit.length > 0);
+        assertTrue(
+            subjectBounds(rabbit)[3] - subjectBounds(rabbit)[1] > 32f,
+            "ears may extend beyond the dominant head crop and are clipped by the atlas cell"
+        );
     }
 
     //#if MC>=11900
@@ -250,6 +252,20 @@ final class EntityHeadGeometryTest {
             }
         }
         return subjectArea;
+    }
+
+    private static float[] subjectBounds(final float[] geometry) {
+        float minX = Float.POSITIVE_INFINITY;
+        float minY = Float.POSITIVE_INFINITY;
+        float maxX = Float.NEGATIVE_INFINITY;
+        float maxY = Float.NEGATIVE_INFINITY;
+        for (int i = 0; i < geometry.length; i += 5) {
+            minX = Math.min(minX, geometry[i]);
+            minY = Math.min(minY, geometry[i + 1]);
+            maxX = Math.max(maxX, geometry[i]);
+            maxY = Math.max(maxY, geometry[i + 1]);
+        }
+        return new float[] {minX, minY, maxX, maxY};
     }
 
 }

--- a/src/test/java/cn/net/rms/confluxmap/mc/radar/EntityIconManagerAtlasTest.java
+++ b/src/test/java/cn/net/rms/confluxmap/mc/radar/EntityIconManagerAtlasTest.java
@@ -1,5 +1,6 @@
 package cn.net.rms.confluxmap.mc.radar;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
@@ -13,5 +14,23 @@ class EntityIconManagerAtlasTest {
         assertEquals(31f / 32f, EntityIconManager.atlasBottomV(0), EPSILON);
         assertEquals(1f / 32f, EntityIconManager.atlasTopV(31), EPSILON);
         assertEquals(0f, EntityIconManager.atlasBottomV(31), EPSILON);
+    }
+
+    @Test
+    void cropsProjectedQuadsToVisibleTextureAlpha() {
+        final float[] quad = {
+            0f, 0f, 0f, 0f, 0f,
+            32f, 0f, 0f, 1f, 0f,
+            32f, 32f, 0f, 1f, 1f,
+            0f, 32f, 0f, 0f, 1f
+        };
+
+        assertArrayEquals(
+            new int[] {8, 4, 24, 28},
+            EntityIconManager.visibleBounds(
+                quad, 32, 32,
+                (x, y) -> x >= 8 && x < 24 && y >= 4 && y < 28 ? 255 : 0
+            )
+        );
     }
 }

--- a/src/test/java/cn/net/rms/confluxmap/mc/radar/RadarIconBorderPolicyTest.java
+++ b/src/test/java/cn/net/rms/confluxmap/mc/radar/RadarIconBorderPolicyTest.java
@@ -1,6 +1,7 @@
 package cn.net.rms.confluxmap.mc.radar;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -9,12 +10,21 @@ import org.junit.jupiter.api.Test;
 
 final class RadarIconBorderPolicyTest {
     @Test
-    void radarIconsHaveNoGeneratedOrDrawTimeBorder() throws IOException {
+    void entityPortraitsHaveAConfigurableShapeFollowingOutline() throws IOException {
         final Path root = findProjectRoot();
         final Path radar = root.resolve("src/main/java/cn/net/rms/confluxmap/mc/radar");
         final String renderer = Files.readString(radar.resolve("RadarMarkerRenderer.java"));
         final String manager = Files.readString(radar.resolve("EntityIconManager.java"));
 
+        assertTrue(renderer.contains("config.radarPlayerIconOutlineEnabled"
+            + " ? config.radarIconOutlineThickness : 0"));
+        assertTrue(renderer.contains("if (outlineThickness > 0)"));
+        assertTrue(renderer.contains("drawIconOutline("));
+        assertTrue(renderer.contains("RenderUtil.drawTintedOutline("));
+        assertFalse(renderer.contains("outerWidth"));
+        assertFalse(renderer.contains("outerHeight"));
+        assertTrue(renderer.contains("final float iconWidth = iconSize * icon.widthScale()"));
+        assertTrue(renderer.contains("final float iconHeight = iconSize * icon.heightScale()"));
         assertFalse(renderer.contains("bindItemOutlineTexture"));
         assertFalse(renderer.contains("bindOutlineTexture"));
         assertFalse(renderer.contains("contourBase("));

--- a/src/test/java/cn/net/rms/confluxmap/mc/radar/RadarMarkerFallbackTest.java
+++ b/src/test/java/cn/net/rms/confluxmap/mc/radar/RadarMarkerFallbackTest.java
@@ -21,7 +21,9 @@ final class RadarMarkerFallbackTest {
 
         assertTrue(renderer.contains("icon != null && drawIcon("));
         assertTrue(renderer.contains("private static boolean drawIcon("));
-        assertTrue(renderer.contains("if (!iconManager.bindDynamicColor()) {\n                return false;"));
+        assertTrue(renderer.matches(
+            "(?s).*if \\(!iconManager\\.bindDynamicColor\\(\\)\\) \\{\\s+return false;.*"
+        ));
     }
 
     private static Path findProjectRoot() {


### PR DESCRIPTION
## Summary

- add an immediate radar portrait outline toggle and a configurable 0-4 px thickness
- apply silhouette-following outlines to player and dynamic entity portraits while leaving item and fallback markers unchanged
- crop dynamic portraits to visible texture alpha, preserve aspect ratio for elongated mobs, and anchor merge badges to the actual portrait bounds
- persist and normalize the new settings with English and Chinese labels

## Testing

- compiled all supported targets: 1.17.1, 1.18.2, 1.20.1, 1.21.1, 1.21.3, 1.21.4, 1.21.5, 1.21.8, 1.21.9, 1.21.11, 26.1.2, 26.2
- passed config copy/normalization/round-trip tests
- passed portrait layout, texture-alpha crop, model geometry, outline policy, fallback, and language resource tests on 1.21.1
- manually verified in the 1.21.1 development client

Closes #65

## Summary by Sourcery

Add configurable silhouette outlines and improved sizing and cropping for radar entity portraits.

New Features:
- Add configurable radar portrait outlines with an immediate enablement toggle and 0–4 px thickness setting.
- Apply silhouette-following outlines to player and dynamic entity portraits while keeping item and fallback markers unoutlined.
- Preserve elongated entity proportions, crop dynamic portraits to visible texture content, and position merge badges using actual portrait dimensions.

Bug Fixes:
- Ensure dynamic portraits and associated labels and badges use their cropped, aspect-preserving bounds.

Enhancements:
- Persist, copy, normalize, and expose the new radar portrait settings in the configuration UI.
- Add English and Chinese labels for the portrait outline controls.
- Update portrait rendering specifications and expand coverage for configuration, layout, alpha cropping, geometry, fallback, and outline policies.

Documentation:
- Document alpha-cropped, aspect-preserving dynamic portraits and configurable silhouette outlines.

Tests:
- Add tests covering outline configuration round trips and defaults, portrait sizing, texture-alpha cropping, model geometry, outline policy, fallback behavior, and language resources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable outlines for player radar icons, including enable/disable controls and adjustable thickness.
  * Improved radar icon sizing and positioning for badges and player names.
  * Dynamic portraits now crop to visible content while preserving aspect ratio.
  * Added English and Chinese translations for the new radar settings.

* **Bug Fixes**
  * Improved portrait fitting to prevent oversized or clipped entity images.
  * Corrected alignment for variable-sized radar icons and related markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->