### PR TITLE
feat(map): edit waypoints from right-click menu

### DIFF
--- a/src/main/java/cn/net/rms/confluxmap/mc/ui/screen/FullscreenMapLocationMenu.java
+++ b/src/main/java/cn/net/rms/confluxmap/mc/ui/screen/FullscreenMapLocationMenu.java
@@ -1,6 +1,7 @@
 package cn.net.rms.confluxmap.mc.ui.screen;
 
 import cn.net.rms.confluxmap.core.model.MapLayer;
+import cn.net.rms.confluxmap.core.waypoint.WaypointRenderEntry;
 import cn.net.rms.confluxmap.mc.world.LayerSelector;
 import java.util.List;
 import java.util.OptionalInt;
@@ -16,6 +17,7 @@ final class FullscreenMapLocationMenu {
 
     enum Action {
         SET_WAYPOINT("confluxmap.map.location_menu.set_waypoint"),
+        EDIT_WAYPOINT("confluxmap.map.location_menu.edit_waypoint"),
         SHARE_LOCATION("confluxmap.map.location_menu.share_location"),
         TELEPORT("confluxmap.map.location_menu.teleport");
 
@@ -30,10 +32,24 @@ final class FullscreenMapLocationMenu {
         }
     }
 
-    private static final List<Action> DEFAULT_ACTIONS = List.of(Action.values());
+    private static final List<Action> DEFAULT_ACTIONS = List.of(
+        Action.SET_WAYPOINT,
+        Action.SHARE_LOCATION,
+        Action.TELEPORT
+    );
     private static final List<Action> TELEPORT_FIRST_ACTIONS = List.of(
         Action.TELEPORT,
         Action.SET_WAYPOINT,
+        Action.SHARE_LOCATION
+    );
+    private static final List<Action> EDIT_ACTIONS = List.of(
+        Action.EDIT_WAYPOINT,
+        Action.SHARE_LOCATION,
+        Action.TELEPORT
+    );
+    private static final List<Action> EDIT_TELEPORT_FIRST_ACTIONS = List.of(
+        Action.TELEPORT,
+        Action.EDIT_WAYPOINT,
         Action.SHARE_LOCATION
     );
     private static final int PANEL_HEIGHT = PANEL_PADDING * 2
@@ -45,6 +61,13 @@ final class FullscreenMapLocationMenu {
 
     static List<Action> actions(final boolean teleportCommandAvailable) {
         return teleportCommandAvailable ? TELEPORT_FIRST_ACTIONS : DEFAULT_ACTIONS;
+    }
+
+    static List<Action> actions(final boolean teleportCommandAvailable, final boolean existingWaypoint) {
+        if (!existingWaypoint) {
+            return actions(teleportCommandAvailable);
+        }
+        return teleportCommandAvailable ? EDIT_TELEPORT_FIRST_ACTIONS : EDIT_ACTIONS;
     }
 
     static boolean actionEnabled(
@@ -59,19 +82,48 @@ final class FullscreenMapLocationMenu {
         return action == Action.TELEPORT ? teleportCommandAvailable : estimatedHeightKnown;
     }
 
+    static boolean actionEnabled(
+        final Action action,
+        final boolean playerPresent,
+        final boolean estimatedHeightKnown,
+        final boolean teleportCommandAvailable,
+        final boolean waypointEditable
+    ) {
+        if (action == Action.EDIT_WAYPOINT) {
+            return playerPresent && waypointEditable;
+        }
+        return actionEnabled(action, playerPresent, estimatedHeightKnown, teleportCommandAvailable);
+    }
+
     static Bounds place(
         final int cursorX,
         final int cursorY,
         final int viewportWidth,
         final int viewportHeight
     ) {
+        return place(cursorX, cursorY, viewportWidth, viewportHeight, DEFAULT_ACTIONS.size());
+    }
+
+    static Bounds place(
+        final int cursorX,
+        final int cursorY,
+        final int viewportWidth,
+        final int viewportHeight,
+        final int actionCount
+    ) {
         final int availableWidth = Math.max(1, viewportWidth - SCREEN_MARGIN * 2);
         final int availableHeight = Math.max(1, viewportHeight - SCREEN_MARGIN * 2);
         final int panelWidth = Math.min(PANEL_WIDTH, availableWidth);
-        final int panelHeight = Math.min(PANEL_HEIGHT, availableHeight);
+        final int panelHeight = Math.min(panelHeight(actionCount), availableHeight);
         final int x = placeAxis(cursorX, panelWidth, viewportWidth);
         final int y = placeAxis(cursorY, panelHeight, viewportHeight);
         return new Bounds(x, y, panelWidth, panelHeight);
+    }
+
+    private static int panelHeight(final int actionCount) {
+        return PANEL_PADDING * 2
+            + actionCount * BUTTON_HEIGHT
+            + Math.max(0, actionCount - 1) * BUTTON_GAP;
     }
 
     private static int placeAxis(final int cursor, final int size, final int viewportSize) {
@@ -82,7 +134,16 @@ final class FullscreenMapLocationMenu {
     }
 
     static Target targetAt(final double worldX, final OptionalInt surfaceY, final double worldZ) {
-        return new Target((int) Math.floor(worldX), surfaceY, (int) Math.floor(worldZ));
+        return targetAt(worldX, surfaceY, worldZ, null);
+    }
+
+    static Target targetAt(
+        final double worldX,
+        final OptionalInt surfaceY,
+        final double worldZ,
+        final WaypointRenderEntry waypoint
+    ) {
+        return new Target((int) Math.floor(worldX), surfaceY, (int) Math.floor(worldZ), waypoint);
     }
 
     static MapLayer topSurfaceLayer(final LayerSelector.DimensionKind dimensionKind) {
@@ -111,9 +172,13 @@ final class FullscreenMapLocationMenu {
         }
     }
 
-    record Target(int blockX, OptionalInt surfaceY, int blockZ) {
+    record Target(int blockX, OptionalInt surfaceY, int blockZ, WaypointRenderEntry waypoint) {
         Target {
             surfaceY = surfaceY == null ? OptionalInt.empty() : surfaceY;
+        }
+
+        boolean existingWaypoint() {
+            return waypoint != null;
         }
 
         OptionalInt blockY() {

--- a/src/main/java/cn/net/rms/confluxmap/mc/ui/screen/FullscreenMapScreen.java
+++ b/src/main/java/cn/net/rms/confluxmap/mc/ui/screen/FullscreenMapScreen.java
@@ -370,6 +370,7 @@ public final class FullscreenMapScreen extends ConfluxScreen {
     private FullscreenMapLocationMenu.Target locationMenuTarget;
     private FullscreenMapLocationMenu.Action pendingLocationAction;
     private ButtonWidget setWaypointLocationButton;
+    private ButtonWidget editWaypointLocationButton;
     private ButtonWidget shareLocationButton;
     private ButtonWidget teleportLocationButton;
     private String teleportLocationUnavailableKey;
@@ -523,6 +524,7 @@ public final class FullscreenMapScreen extends ConfluxScreen {
         sharedVisibilityButton = null;
         manageWaypointsButton = null;
         setWaypointLocationButton = null;
+        editWaypointLocationButton = null;
         shareLocationButton = null;
         teleportLocationButton = null;
         teleportLocationUnavailableKey = null;
@@ -1473,8 +1475,10 @@ public final class FullscreenMapScreen extends ConfluxScreen {
         );
         final boolean teleportCommandAvailable = teleportAccess.available();
         teleportLocationUnavailableKey = teleportAccess.reasonKey();
+        final boolean existingWaypoint = locationMenuTarget.existingWaypoint();
+        final boolean waypointEditable = existingWaypoint && waypointEditable(locationMenuTarget.waypoint());
         final List<FullscreenMapLocationMenu.Action> actions = FullscreenMapLocationMenu.actions(
-            teleportCommandAvailable
+            teleportCommandAvailable, existingWaypoint
         );
         for (int index = 0; index < actions.size(); index++) {
             final FullscreenMapLocationMenu.Action action = actions.get(index);
@@ -1487,13 +1491,14 @@ public final class FullscreenMapScreen extends ConfluxScreen {
                 ignored -> pendingLocationAction = action
             ));
             button.active = FullscreenMapLocationMenu.actionEnabled(
-                action, playerPresent, heightKnown, teleportCommandAvailable
+                action, playerPresent, heightKnown, teleportCommandAvailable, waypointEditable
             );
             if (!viewingLiveWorld() && action == FullscreenMapLocationMenu.Action.SHARE_LOCATION) {
                 button.active = false;
             }
             switch (action) {
                 case SET_WAYPOINT -> setWaypointLocationButton = button;
+                case EDIT_WAYPOINT -> editWaypointLocationButton = button;
                 case SHARE_LOCATION -> shareLocationButton = button;
                 case TELEPORT -> teleportLocationButton = button;
             }
@@ -1528,7 +1533,8 @@ public final class FullscreenMapScreen extends ConfluxScreen {
             );
             if (surfaceY.isPresent()) {
                 locationMenuTarget = FullscreenMapLocationMenu.targetAt(
-                    locationMenuTarget.blockX(), surfaceY, locationMenuTarget.blockZ()
+                    locationMenuTarget.blockX(), surfaceY, locationMenuTarget.blockZ(),
+                    locationMenuTarget.waypoint()
                 );
                 rebuildWaypointControls();
             }
@@ -1849,15 +1855,17 @@ public final class FullscreenMapScreen extends ConfluxScreen {
         final double worldZ = centerZ + (mouseY - height / 2.0) * scale;
         final int blockX = (int) Math.floor(worldX);
         final int blockZ = (int) Math.floor(worldZ);
+        final WaypointRenderEntry waypoint = waypointAt(mouseX, mouseY);
         final int menuViewportWidth = width - MARGIN - CONTROL_SIZE - CONTROL_GAP;
         locationMenuBounds = FullscreenMapLocationMenu.place(
             (int) Math.floor(mouseX),
             (int) Math.floor(mouseY),
             menuViewportWidth,
-            height
+            height,
+            FullscreenMapLocationMenu.actions(false, waypoint != null).size()
         );
         locationMenuTarget = FullscreenMapLocationMenu.targetAt(
-            worldX, surfaceYAt(blockX, blockZ), worldZ
+            worldX, surfaceYAt(blockX, blockZ), worldZ, waypoint
         );
         pendingLocationAction = null;
         mapPointerPress = false;
@@ -1901,6 +1909,11 @@ public final class FullscreenMapScreen extends ConfluxScreen {
                     this::viewWaypointStore
                 )
             ));
+            case EDIT_WAYPOINT -> {
+                if (target.waypoint() != null) {
+                    openWaypointFromLocationMenu(target.waypoint());
+                }
+            }
             case SHARE_LOCATION -> {
                 if (target.blockY().isPresent()) {
                     shareTemporaryLocation(target);
@@ -1945,6 +1958,52 @@ public final class FullscreenMapScreen extends ConfluxScreen {
         locationMenuTarget = null;
         pendingLocationAction = null;
         rebuildWaypointControls();
+    }
+
+    private boolean waypointEditable(final WaypointRenderEntry waypoint) {
+        if (waypoint == null) {
+            return false;
+        }
+        if (waypoint.local()) {
+            final WaypointStore store = viewWaypointStore();
+            return store != null && store.persistenceWritable();
+        }
+        return sharedWaypoints.find(waypoint.id()).map(sharedWaypoints::canUpdate).orElse(false);
+    }
+
+    private void openWaypointFromLocationMenu(final WaypointRenderEntry waypoint) {
+        if (waypoint.local()) {
+            viewWaypointService().list().stream()
+                .filter(local -> local.id.equals(waypoint.id()))
+                .findFirst()
+                .ifPresent(local -> MinecraftAccess.setScreen(
+                    MinecraftClient.getInstance(), WaypointEditScreen.forEdit(
+                        this, local, this::viewWaypointStore
+                    )
+                ));
+            return;
+        }
+        sharedWaypoints.find(waypoint.id())
+            .filter(sharedWaypoints::canUpdate)
+            .ifPresent(shared -> MinecraftAccess.setScreen(
+                MinecraftClient.getInstance(), WaypointEditScreen.forPublicEdit(this, shared)
+            ));
+    }
+
+    private WaypointRenderEntry waypointAt(final double mouseX, final double mouseY) {
+        WaypointRenderEntry closest = null;
+        double closestDistance = HOVER_RADIUS_PX;
+        final double pxPerBlock = 1.0 / scale;
+        for (final WaypointRenderEntry waypoint : viewWaypointRenderCatalog().snapshot(viewSession().dimension())) {
+            final double screenX = width / 2.0 + (waypoint.x() - centerX) * pxPerBlock;
+            final double screenY = height / 2.0 + (waypoint.z() - centerZ) * pxPerBlock;
+            final double distance = Math.hypot(mouseX - screenX, mouseY - screenY);
+            if (distance <= closestDistance) {
+                closestDistance = distance;
+                closest = waypoint;
+            }
+        }
+        return closest;
     }
 
     /**

--- a/src/main/resources/assets/confluxmap/lang/en_us.json
+++ b/src/main/resources/assets/confluxmap/lang/en_us.json
@@ -152,6 +152,7 @@
   "confluxmap.map.target.dimension": "Dimension",
   "confluxmap.screen.map_view.current_world": "Current World",
   "confluxmap.map.location_menu.set_waypoint": "Set Waypoint",
+  "confluxmap.map.location_menu.edit_waypoint": "Edit Waypoint",
   "confluxmap.map.location_menu.share_location": "Share Location",
   "confluxmap.map.location_menu.teleport": "Teleport Here",
   "confluxmap.map.location_menu.temporary_name": "Shared Location",

--- a/src/main/resources/assets/confluxmap/lang/zh_cn.json
+++ b/src/main/resources/assets/confluxmap/lang/zh_cn.json
@@ -152,6 +152,7 @@
   "confluxmap.map.target.dimension": "维度",
   "confluxmap.screen.map_view.current_world": "当前世界",
   "confluxmap.map.location_menu.set_waypoint": "设置路径点",
+  "confluxmap.map.location_menu.edit_waypoint": "编辑路径点",
   "confluxmap.map.location_menu.share_location": "分享位置",
   "confluxmap.map.location_menu.teleport": "传送到此处",
   "confluxmap.map.location_menu.temporary_name": "共享位置",

--- a/src/test/java/cn/net/rms/confluxmap/mc/ui/screen/FullscreenMapLocationMenuTest.java
+++ b/src/test/java/cn/net/rms/confluxmap/mc/ui/screen/FullscreenMapLocationMenuTest.java
@@ -30,6 +30,30 @@ class FullscreenMapLocationMenuTest {
     }
 
     @Test
+    void replacesCreateActionWithEditForAnExistingWaypoint() {
+        assertEquals(List.of(
+            FullscreenMapLocationMenu.Action.EDIT_WAYPOINT,
+            FullscreenMapLocationMenu.Action.SHARE_LOCATION,
+            FullscreenMapLocationMenu.Action.TELEPORT
+        ), FullscreenMapLocationMenu.actions(false, true));
+        assertEquals(List.of(
+            FullscreenMapLocationMenu.Action.TELEPORT,
+            FullscreenMapLocationMenu.Action.EDIT_WAYPOINT,
+            FullscreenMapLocationMenu.Action.SHARE_LOCATION
+        ), FullscreenMapLocationMenu.actions(true, true));
+    }
+
+    @Test
+    void editActionOnlyDependsOnWaypointPermission() {
+        assertTrue(FullscreenMapLocationMenu.actionEnabled(
+            FullscreenMapLocationMenu.Action.EDIT_WAYPOINT, true, false, false, true
+        ));
+        assertFalse(FullscreenMapLocationMenu.actionEnabled(
+            FullscreenMapLocationMenu.Action.EDIT_WAYPOINT, true, false, false, false
+        ));
+    }
+
+    @Test
     void opensBesideTheCursorWithoutLeavingTheViewport() {
         final FullscreenMapLocationMenu.Bounds topLeft = FullscreenMapLocationMenu.place(20, 20, 320, 240);
         final FullscreenMapLocationMenu.Bounds bottomRight = FullscreenMapLocationMenu.place(315, 235, 320, 240);


### PR DESCRIPTION
## Summary
- show an edit action when right-clicking an existing waypoint on the fullscreen map
- reuse local and public waypoint edit screens with existing permission checks
- keep create/share/teleport actions for empty map locations
- add English and Simplified Chinese translations and menu tests

Closes #88

## Verification
- `./gradlew :1.21.1:compileJava --no-daemon`
- `./gradlew :1.17.1:compileJava --no-daemon`
- `./gradlew :1.21.1:test --tests cn.net.rms.confluxmap.mc.ui.screen.FullscreenMapLocationMenuTest -x :common:test --no-daemon`

The full test suite still has the existing unrelated `MapExportServiceTest.cancelledTileIsReportedAsFailureWithItsReason` failure.

## Summary by Sourcery

Enable editing waypoints directly from the fullscreen map right-click menu.

New Features:
- Add an edit action for existing waypoints in the fullscreen map location menu.
- Reuse waypoint editing screens for local and shared waypoints while enforcing existing edit permissions.

Enhancements:
- Preserve create, share, and teleport actions for empty map locations and adjust menu layout for waypoint-specific actions.

Tests:
- Add coverage for waypoint menu actions and edit-action permission handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to edit existing waypoints directly from the fullscreen map.
  * The edit option appears when a waypoint is selected and is enabled only when editing is permitted.
  * Added support for opening both local and shared waypoint editors.
  * Added English and Chinese labels for the new edit action.

* **Tests**
  * Added coverage for waypoint editing, action ordering, and permission handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->