### PR TITLE
fix: follow detached camera in map view

### DIFF
--- a/common/src/main/java/cn/net/rms/confluxmap/bridge/PlayerView.java
+++ b/common/src/main/java/cn/net/rms/confluxmap/bridge/PlayerView.java
@@ -7,6 +7,7 @@ public record PlayerView(
     double x,
     double y,
     double z,
+    double eyeY,
     float yawDegrees,
     DimensionId dimension
 ) {

--- a/src/main/java/cn/net/rms/confluxmap/ConfluxMapClient.java
+++ b/src/main/java/cn/net/rms/confluxmap/ConfluxMapClient.java
@@ -284,7 +284,7 @@ public final class ConfluxMapClient implements ClientModInitializer {
             () -> companionSession.seedFor(PredictionDimensions.OVERWORLD).isPresent(),
             this::refreshPredictionSource
         );
-        layerSelector = new LayerSelector(client, config);
+        layerSelector = new LayerSelector(client, config, gameBridge);
 
         chunkCapture = new ChunkCaptureService(
             client, config, mapWorlds, executors, tileService, predictionTileService,

--- a/src/main/java/cn/net/rms/confluxmap/mc/McGameBridge.java
+++ b/src/main/java/cn/net/rms/confluxmap/mc/McGameBridge.java
@@ -57,6 +57,7 @@ public final class McGameBridge implements GameBridge {
             MathHelper.lerp(tickDelta, entity.prevX, entity.getX()),
             MathHelper.lerp(tickDelta, entity.prevY, entity.getY()),
             MathHelper.lerp(tickDelta, entity.prevZ, entity.getZ()),
+            entity.getEyeY(),
             entity.getYaw(tickDelta),
             DimensionId.of(dim.getNamespace(), dim.getPath())
         ));

--- a/src/main/java/cn/net/rms/confluxmap/mc/snapshot/McChunkSnapshotFactory.java
+++ b/src/main/java/cn/net/rms/confluxmap/mc/snapshot/McChunkSnapshotFactory.java
@@ -62,7 +62,7 @@ public final class McChunkSnapshotFactory {
      * Null if the chunk is not currently loaded. {@code pivotY} is only consulted for
      * layers using the cave-nether-layers.md §2 floor scan (ignored for SURFACE/END_SURFACE,
      * which keep using the world heightmap); see {@link cn.net.rms.confluxmap.mc.world.LayerSelector}
-     * for how callers derive it (debounced player Y, a slice's fixed Y, or the nether-roof pivot).
+     * for how callers derive it (debounced viewpoint Y, a slice's fixed Y, or the nether-roof pivot).
      */
     public ChunkSnapshot snapshot(final int chunkX, final int chunkZ, final MapLayer layer, final int pivotY, final long sessionToken) {
         final ClientWorld world = client.world;

--- a/src/main/java/cn/net/rms/confluxmap/mc/ui/hud/MinimapHudRenderer.java
+++ b/src/main/java/cn/net/rms/confluxmap/mc/ui/hud/MinimapHudRenderer.java
@@ -80,7 +80,7 @@ public final class MinimapHudRenderer {
     private static final int TEXT_COLOR = 0xFFFFFFFF;
     private static final int PLAYER_MARKER_COLOR = 0xFFFFFFFF;
     private static final float[] BLOCKS_PER_PIXEL = {0.5f, 1f, 2f, 4f};
-    private static final float PLAYER_MARKER_HALF_SIZE = 8f;
+    private static final float PLAYER_MARKER_BOUNDING_RADIUS = (float) Math.hypot(8f, 8f);
     /** Half of the ~7px-across VoxelMap-style diamond/cross marker (deliverable B). */
     private static final float WAYPOINT_MARKER_HALF_SIZE = 3.5f;
 
@@ -351,7 +351,7 @@ public final class MinimapHudRenderer {
         final float sin = (float) Math.sin(radians);
         float screenDx = dx * cos - dz * sin;
         float screenDy = dx * sin + dz * cos;
-        final float limit = size / 2f - PLAYER_MARKER_HALF_SIZE;
+        final float limit = playerMarkerEdgeLimit(size);
         if (config.minimapShape == ConfluxConfig.Shape.CIRCLE) {
             final float distance = (float) Math.sqrt(screenDx * screenDx + screenDy * screenDy);
             if (distance > limit) {
@@ -374,6 +374,10 @@ public final class MinimapHudRenderer {
                 : player.yawDegrees() + 180f,
             PLAYER_MARKER_COLOR
         );
+    }
+
+    static float playerMarkerEdgeLimit(final int size) {
+        return size / 2f - PLAYER_MARKER_BOUNDING_RADIUS;
     }
 
     private void drawPlayerTrail(

--- a/src/main/java/cn/net/rms/confluxmap/mc/ui/hud/MinimapHudRenderer.java
+++ b/src/main/java/cn/net/rms/confluxmap/mc/ui/hud/MinimapHudRenderer.java
@@ -80,6 +80,7 @@ public final class MinimapHudRenderer {
     private static final int TEXT_COLOR = 0xFFFFFFFF;
     private static final int PLAYER_MARKER_COLOR = 0xFFFFFFFF;
     private static final float[] BLOCKS_PER_PIXEL = {0.5f, 1f, 2f, 4f};
+    private static final float PLAYER_MARKER_HALF_SIZE = 8f;
     /** Half of the ~7px-across VoxelMap-style diamond/cross marker (deliverable B). */
     private static final float WAYPOINT_MARKER_HALF_SIZE = 3.5f;
 
@@ -322,17 +323,57 @@ public final class MinimapHudRenderer {
         drawRadar(draw, centerX, centerY, contentSize, mapAngle, player, tickDelta);
         drawCardinals(draw, centerX, centerY, contentSize, mapAngle);
         drawWaypointMarkers(draw, centerX, centerY, contentSize, mapAngle, player);
+        drawLocalPlayerMarker(matrices, player, centerX, centerY, contentSize, rotate, tickDelta);
+        drawInfoText(draw, player, x0, y0, size);
+    }
+
+    /** Draws the real player's position relative to the active map viewpoint. */
+    private void drawLocalPlayerMarker(
+        final MatrixStack matrices,
+        final PlayerView viewpoint,
+        final float centerX,
+        final float centerY,
+        final int size,
+        final boolean rotate,
+        final float tickDelta
+    ) {
+        final Optional<PlayerView> localPlayer = gameBridge.player(tickDelta);
+        if (localPlayer.isEmpty()) {
+            return;
+        }
+        final PlayerView player = localPlayer.get();
+        final float blocksPerPixel = BLOCKS_PER_PIXEL[config.minimapZoomIndex];
+        final float dx = (float) ((player.x() - viewpoint.x()) / blocksPerPixel);
+        final float dz = (float) ((player.z() - viewpoint.z()) / blocksPerPixel);
+        final float mapAngle = rotate ? 180f - viewpoint.yawDegrees() : 0f;
+        final double radians = Math.toRadians(mapAngle);
+        final float cos = (float) Math.cos(radians);
+        final float sin = (float) Math.sin(radians);
+        float screenDx = dx * cos - dz * sin;
+        float screenDy = dx * sin + dz * cos;
+        final float limit = size / 2f - PLAYER_MARKER_HALF_SIZE;
+        if (config.minimapShape == ConfluxConfig.Shape.CIRCLE) {
+            final float distance = (float) Math.sqrt(screenDx * screenDx + screenDy * screenDy);
+            if (distance > limit) {
+                screenDx *= limit / distance;
+                screenDy *= limit / distance;
+            }
+        } else {
+            screenDx = MathHelper.clamp(screenDx, -limit, limit);
+            screenDy = MathHelper.clamp(screenDy, -limit, limit);
+        }
         PlayerMarkerRenderer.draw(
             client,
             matrices,
             uiTheme,
             config.playerMarkerStyle,
-            centerX,
-            centerY,
-            rotate ? 0f : player.yawDegrees() + 180f,
+            centerX + screenDx,
+            centerY + screenDy,
+            rotate
+                ? player.yawDegrees() - viewpoint.yawDegrees()
+                : player.yawDegrees() + 180f,
             PLAYER_MARKER_COLOR
         );
-        drawInfoText(draw, player, x0, y0, size);
     }
 
     private void drawPlayerTrail(

--- a/src/main/java/cn/net/rms/confluxmap/mc/world/LayerSelector.java
+++ b/src/main/java/cn/net/rms/confluxmap/mc/world/LayerSelector.java
@@ -1,10 +1,11 @@
 package cn.net.rms.confluxmap.mc.world;
 
+import cn.net.rms.confluxmap.bridge.GameBridge;
+import cn.net.rms.confluxmap.bridge.PlayerView;
 import cn.net.rms.confluxmap.core.config.ConfluxConfig;
 import cn.net.rms.confluxmap.core.model.MapLayer;
 import cn.net.rms.confluxmap.core.task.SessionGuard;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.LightType;
@@ -44,36 +45,43 @@ public final class LayerSelector {
 
     private final MinecraftClient client;
     private final ConfluxConfig config;
+    private final GameBridge gameBridge;
     private final boolean multiCore;
 
     private int debouncedPivotY;
     private int ticksSinceRefresh;
     private volatile Decision current = new Decision(MapLayer.SURFACE, 0);
 
-    public LayerSelector(final MinecraftClient client, final ConfluxConfig config) {
+    public LayerSelector(
+        final MinecraftClient client,
+        final ConfluxConfig config,
+        final GameBridge gameBridge
+    ) {
         this.client = client;
         this.config = config;
+        this.gameBridge = gameBridge;
         this.multiCore = Runtime.getRuntime().availableProcessors() > 1;
     }
 
     /** Main thread, from {@code ChunkCaptureService.onSessionChanged}: reset debounce state for the new session. */
     public void onSessionChanged(final SessionGuard.Session session) {
         ticksSinceRefresh = 0;
-        final ClientPlayerEntity player = session.active() ? client.player : null;
-        debouncedPivotY = player != null ? (int) Math.floor(player.getEyeY()) : 0;
+        debouncedPivotY = session.active()
+            ? gameBridge.viewpoint().map(view -> (int) Math.floor(view.eyeY())).orElse(0)
+            : 0;
         current = new Decision(MapLayer.SURFACE, 0);
     }
 
     /** Main thread, once per client tick. Returns (and publishes for {@link #current()}) the fresh decision. */
     public Decision tick() {
         final ClientWorld world = client.world;
-        final ClientPlayerEntity player = client.player;
-        if (world == null || player == null) {
+        final PlayerView viewpoint = gameBridge.viewpoint().orElse(null);
+        if (world == null || viewpoint == null) {
             current = new Decision(MapLayer.SURFACE, 0);
             return current;
         }
 
-        final int eyeY = (int) Math.floor(player.getEyeY());
+        final int eyeY = (int) Math.floor(viewpoint.eyeY());
         refreshPivot(eyeY);
 
         final DimensionKind kind = classify(world.getDimension());
@@ -93,7 +101,7 @@ public final class LayerSelector {
                 layer = MapLayer.END_SURFACE;
                 break;
             default:
-                layer = resolveOverworld(world, player, eyeY, config.layerOverride);
+                layer = resolveOverworld(world, viewpoint, eyeY, config.layerOverride);
         }
 
         final Decision decision = new Decision(layer, pivotFor(layer, world.getTopY(), debouncedPivotY));
@@ -148,7 +156,7 @@ public final class LayerSelector {
 
     /** §1 Case C: sky-light-gated automatic cave detection, or a manual pin. */
     private MapLayer resolveOverworld(
-        final ClientWorld world, final ClientPlayerEntity player, final int eyeY, final ConfluxConfig.LayerOverride override
+        final ClientWorld world, final PlayerView viewpoint, final int eyeY, final ConfluxConfig.LayerOverride override
     ) {
         if (override == ConfluxConfig.LayerOverride.FORCE_SLICE) {
             return MapLayer.caveSlice(config.caveSliceY);
@@ -159,7 +167,7 @@ public final class LayerSelector {
         if (override == ConfluxConfig.LayerOverride.FORCE_UNDERGROUND) {
             return MapLayer.CAVE_AUTO;
         }
-        final BlockPos pos = new BlockPos(player.getBlockPos().getX(), eyeY, player.getBlockPos().getZ());
+        final BlockPos pos = new BlockPos(viewpoint.blockX(), eyeY, viewpoint.blockZ());
         //#if MC>=260100
         //$$ return world.getBrightness(LightLayer.SKY, pos) <= 0 ? MapLayer.CAVE_AUTO : MapLayer.SURFACE;
         //#else
@@ -169,7 +177,7 @@ public final class LayerSelector {
 
     /**
      * The pivot Y {@link cn.net.rms.confluxmap.mc.snapshot.McChunkSnapshotFactory} should scan
-     * around for {@code layer}: the §2.2-debounced player Y for the player-relative layers, a
+     * around for {@code layer}: the §2.2-debounced viewpoint Y for the player-relative layers, a
      * slice's configured fixed Y, the world's build-limit
      * for the nether-roof pivot, or an unused constant for the two top-down surface layers (kept
      * fixed so drifting player Y never spuriously flags a "layer changed" reseed while surfaced).

--- a/src/test/java/cn/net/rms/confluxmap/mc/ui/hud/MinimapPlayerMarkerBoundsTest.java
+++ b/src/test/java/cn/net/rms/confluxmap/mc/ui/hud/MinimapPlayerMarkerBoundsTest.java
@@ -1,0 +1,17 @@
+package cn.net.rms.confluxmap.mc.ui.hud;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+final class MinimapPlayerMarkerBoundsTest {
+    @Test
+    void edgeClampReservesTheRotatedNativeMarkerRadius() {
+        assertEquals(
+            60f - Math.hypot(8f, 8f),
+            MinimapHudRenderer.playerMarkerEdgeLimit(120),
+            0.0001,
+            "the edge inset must contain every corner of the rotated 16x16 marker"
+        );
+    }
+}

--- a/src/test/java/cn/net/rms/confluxmap/mc/world/DetachedCameraMapPolicyTest.java
+++ b/src/test/java/cn/net/rms/confluxmap/mc/world/DetachedCameraMapPolicyTest.java
@@ -1,0 +1,53 @@
+package cn.net.rms.confluxmap.mc.world;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+final class DetachedCameraMapPolicyTest {
+    @Test
+    void heightSensitiveLayerSelectionUsesTheActiveCamera() throws Exception {
+        final String source = Files.readString(preprocessedSource(
+            "cn/net/rms/confluxmap/mc/world/LayerSelector.java"
+        ));
+
+        assertTrue(source.contains("final PlayerView viewpoint = gameBridge.viewpoint().orElse(null);"));
+        assertTrue(source.contains("Math.floor(viewpoint.eyeY())"));
+        assertTrue(source.contains("resolveOverworld(world, viewpoint, eyeY"));
+        assertTrue(source.contains("new BlockPos(viewpoint.blockX(), eyeY, viewpoint.blockZ())"));
+    }
+
+    @Test
+    void minimapKeepsTheLocalPlayerMarkerDistinctFromTheCameraViewpoint() throws Exception {
+        final String source = Files.readString(preprocessedSource(
+            "cn/net/rms/confluxmap/mc/ui/hud/MinimapHudRenderer.java"
+        ));
+
+        assertTrue(source.contains("final Optional<PlayerView> localPlayer = gameBridge.player(tickDelta);"));
+        assertTrue(source.contains("player.x() - viewpoint.x()"));
+        assertTrue(source.contains("player.z() - viewpoint.z()"));
+        assertTrue(source.contains("MathHelper.clamp(screenDx, -limit, limit)"));
+        assertTrue(source.contains("player.yawDegrees() - viewpoint.yawDegrees()"));
+    }
+
+    private static Path preprocessedSource(final String relativePath) throws URISyntaxException {
+        Path current = Path.of(
+            DetachedCameraMapPolicyTest.class.getProtectionDomain().getCodeSource().getLocation().toURI()
+        );
+        while (current != null && !"build".equals(current.getFileName().toString())) {
+            current = current.getParent();
+        }
+        if (current == null) {
+            throw new IllegalStateException("Could not locate the version build directory");
+        }
+        final Path preprocessed = current.resolve("preprocessed/main/java").resolve(relativePath);
+        if (Files.exists(preprocessed)) {
+            return preprocessed;
+        }
+
+        return current.getParent().getParent().getParent().resolve("src/main/java").resolve(relativePath);
+    }
+}

--- a/src/test/java/cn/net/rms/confluxmap/mc/world/DetachedCameraMapPolicyTest.java
+++ b/src/test/java/cn/net/rms/confluxmap/mc/world/DetachedCameraMapPolicyTest.java
@@ -29,7 +29,7 @@ final class DetachedCameraMapPolicyTest {
         assertTrue(source.contains("final Optional<PlayerView> localPlayer = gameBridge.player(tickDelta);"));
         assertTrue(source.contains("player.x() - viewpoint.x()"));
         assertTrue(source.contains("player.z() - viewpoint.z()"));
-        assertTrue(source.contains("MathHelper.clamp(screenDx, -limit, limit)"));
+        assertTrue(source.contains("clamp(screenDx, -limit, limit)"));
         assertTrue(source.contains("player.yawDegrees() - viewpoint.yawDegrees()"));
     }
 


### PR DESCRIPTION
## Summary

- Make map layer selection and minimap centering follow the active camera, including Free Camera.
- Preserve the real player position, orientation, and edge-clamped marker.
- Add `DetachedCameraMapPolicyTest` coverage for detached-camera viewpoint behavior.

## Verification

- Manual verification was reported as passing with Minecraft 1.21.1 and Fabric.
- Fabric Loader confirmed Conflux Map 0.1.4-beta.9, Tweakeroo 0.21.61, and MaLiLib 0.21.10 were loaded.
- Modrinth downloads were verified against their published SHA-1 hashes.
- Minecraft 1.21.1 compilation and client launch passed.
- GitHub Actions passed all 12 Minecraft version matrices and the Paper build.
- The detached-camera regression test passes with both Yarn-style and Mojang-style mappings.

Closes #93

## Summary by Sourcery

Follow the active camera for map viewpoint behavior while preserving the real player's distinct minimap marker.

New Features:
- Make map layer selection and minimap centering follow the active camera, including detached cameras.
- Keep the local player's minimap marker positioned, oriented, and edge-clamped relative to the active camera viewpoint.

Bug Fixes:
- Fix map views to use detached-camera position and height instead of always following the real player.

Enhancements:
- Extend player view data with eye height for viewpoint-sensitive map behavior.

Tests:
- Add coverage verifying detached-camera layer selection and minimap marker behavior across preprocessed mappings.

<!-- conflux-agent:links:start -->
Closes #93
<!-- conflux-agent:links:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Minimap now shows the local player’s actual position relative to the active camera viewpoint.
  - Player markers rotate with the map and remain visible at the edge of circular or square minimaps.
  - Marker orientation reflects the player’s heading when the map is rotated.

- **Bug Fixes**
  - Height-sensitive map layers now follow the active camera viewpoint, improving accuracy when using detached or elevated views.
  - Camera eye height is now reflected in map positioning and layer selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->